### PR TITLE
Update maintainers/license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Cameron Sparr and contributors.
+Copyright 2022 The Prometheus Authors
+Copyright 2016 Cameron Sparr and contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,4 @@
+# Maintainers
+
+* Ben Kochie <superq@gmail.com> @SuperQ
+* Matthias Loibl <mail@matthiasloibl.com> @metalmatze

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Circle CI](https://circleci.com/gh/prometheus-community/pro-bing.svg?style=svg)](https://circleci.com/gh/prometheus-community/pro-bing)
 
 A simple but powerful ICMP echo (ping) library for Go, inspired by
-[go-ping](github.com/go-ping/ping) & [go-fastping](https://github.com/tatsushid/go-fastping).
+[go-ping](https://github.com/go-ping/ping) & [go-fastping](https://github.com/tatsushid/go-fastping).
 
 Here is a very simple example that sends and receives three packets:
 
@@ -130,11 +130,7 @@ language.
 
 This repo was originally in the personal account of
 [sparrc](https://github.com/sparrc), but is now maintained by the
-[go-ping organization](https://github.com/go-ping).
-
-For support and help, you usually find us in the #go-ping channel of
-Gophers Slack. See https://invite.slack.golangbridge.org/ for an invite
-to the Gophers Slack org.
+[Prometheus Community](https://prometheus.io/community).
 
 ## Contributing
 


### PR DESCRIPTION
* Add Prometheus Authors copyright going forward.
* Add a maintainers file.

Signed-off-by: SuperQ <superq@gmail.com>