### PR TITLE
Add context based Run API

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -53,6 +53,7 @@ package probing
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -401,6 +402,13 @@ func (p *Pinger) ID() int {
 // done. If Count or Interval are not specified, it will run continuously until
 // it is interrupted.
 func (p *Pinger) Run() error {
+	return p.RunWithContext(context.Background())
+}
+
+// RunWithContext runs the pinger with a context. This is a blocking function that will exit when it's
+// done or if the context is canceled. If Count or Interval are not specified, it will run continuously until
+// it is interrupted.
+func (p *Pinger) RunWithContext(ctx context.Context) error {
 	var conn packetConn
 	var err error
 	if p.Size < timeSliceLength+trackerLength {
@@ -418,10 +426,10 @@ func (p *Pinger) Run() error {
 	defer conn.Close()
 
 	conn.SetTTL(p.TTL)
-	return p.run(conn)
+	return p.run(ctx, conn)
 }
 
-func (p *Pinger) run(conn packetConn) error {
+func (p *Pinger) run(ctx context.Context, conn packetConn) error {
 	if err := conn.SetFlagTTL(); err != nil {
 		return err
 	}
@@ -434,7 +442,16 @@ func (p *Pinger) run(conn packetConn) error {
 		handler()
 	}
 
-	var g errgroup.Group
+	g, ctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		select {
+		case <-ctx.Done():
+			p.Stop()
+		case <-p.done:
+		}
+		return nil
+	})
 
 	g.Go(func() error {
 		defer p.Stop()

--- a/ping_test.go
+++ b/ping_test.go
@@ -2,6 +2,7 @@ package probing
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"net"
 	"runtime/debug"
@@ -667,7 +668,7 @@ func TestRunBadWrite(t *testing.T) {
 
 	var conn testPacketConnBadWrite
 
-	err = pinger.run(conn)
+	err = pinger.run(context.Background(), conn)
 	AssertTrue(t, err != nil)
 
 	stats := pinger.Statistics()
@@ -696,7 +697,7 @@ func TestRunBadRead(t *testing.T) {
 
 	var conn testPacketConnBadRead
 
-	err = pinger.run(conn)
+	err = pinger.run(context.Background(), conn)
 	AssertTrue(t, err != nil)
 
 	stats := pinger.Statistics()
@@ -749,7 +750,7 @@ func TestRunOK(t *testing.T) {
 
 	conn := new(testPacketConnOK)
 
-	err = pinger.run(conn)
+	err = pinger.run(context.Background(), conn)
 	AssertTrue(t, err == nil)
 
 	stats := pinger.Statistics()
@@ -761,4 +762,50 @@ func TestRunOK(t *testing.T) {
 	AssertTrue(t, stats.PacketsRecv == 1)
 	AssertTrue(t, stats.MinRtt >= 10*time.Millisecond)
 	AssertTrue(t, stats.MinRtt <= 12*time.Millisecond)
+}
+
+func TestRunWithTimeoutContext(t *testing.T) {
+	pinger := New("127.0.0.1")
+
+	err := pinger.Resolve()
+	AssertNoError(t, err)
+
+	conn := new(testPacketConnOK)
+
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err = pinger.run(ctx, conn)
+	AssertTrue(t, err == nil)
+	elapsedTime := time.Since(start)
+	AssertTrue(t, elapsedTime < 10*time.Second)
+
+	stats := pinger.Statistics()
+	AssertTrue(t, stats != nil)
+	if stats == nil {
+		t.FailNow()
+	}
+	AssertTrue(t, stats.PacketsSent > 0)
+	AssertTrue(t, stats.PacketsRecv > 0)
+}
+
+func TestRunWithBackgroundContext(t *testing.T) {
+	pinger := New("127.0.0.1")
+	pinger.Count = 10
+	pinger.Interval = 100 * time.Millisecond
+
+	err := pinger.Resolve()
+	AssertNoError(t, err)
+
+	conn := new(testPacketConnOK)
+
+	err = pinger.run(context.Background(), conn)
+	AssertTrue(t, err == nil)
+
+	stats := pinger.Statistics()
+	AssertTrue(t, stats != nil)
+	if stats == nil {
+		t.FailNow()
+	}
+	AssertTrue(t, stats.PacketsRecv == 10)
 }


### PR DESCRIPTION
## Description
This adds a context based API. This is useful for code which has an existing context and wants to rely on that instead of using a timeout or a count of packets to stop the pinger. When the context is canceled, the ping object is stopped.

I've also added a mutex to the tests as there is a data race detected in testPacketConnOK
See 
```
make test                                                                                                
>> running all tests
GO111MODULE= go test -race -cover  ./...
==================
WARNING: DATA RACE
Write at 0x00c00018f7a8 by goroutine 17:
  github.com/prometheus-community/pro-bing.(*testPacketConnOK).WriteTo()
      /Users/qjarrell/repos/pro-bing/ping_test.go:720 +0x75
  github.com/prometheus-community/pro-bing.(*Pinger).sendICMP()
      /Users/qjarrell/repos/pro-bing/ping.go:752 +0x92a
  github.com/prometheus-community/pro-bing.(*Pinger).runLoop()
      /Users/qjarrell/repos/pro-bing/ping.go:509 +0x4c4
  github.com/prometheus-community/pro-bing.(*Pinger).run.func3()
      /Users/qjarrell/repos/pro-bing/ping.go:463 +0xcf
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/qjarrell/git/go/1.18.2/pkg/mod/golang.org/x/sync@v0.1.0/errgroup/errgroup.go:75 +0x86

Previous read at 0x00c00018f7a8 by goroutine 14:
  github.com/prometheus-community/pro-bing.(*testPacketConnOK).ReadFrom()
      /Users/qjarrell/repos/pro-bing/ping_test.go:731 +0x55
  github.com/prometheus-community/pro-bing.(*Pinger).recvICMP()
      /Users/qjarrell/repos/pro-bing/ping.go:605 +0x1cd
  github.com/prometheus-community/pro-bing.(*Pinger).run.func2()
      /Users/qjarrell/repos/pro-bing/ping.go:458 +0xcf
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/qjarrell/git/go/1.18.2/pkg/mod/golang.org/x/sync@v0.1.0/errgroup/errgroup.go:75 +0x86
==================
```

## Compatibility
This change is backwards compatible for the current API but brings in a new dependency, context, which was added in Go 1.7. If a user is on an older than 1.7 version then they will not be able to move to the new version of pro-bing without upgrading their go version.

## Testing
Added two unit tests
* First test runs a context with a timer which expires in 100 ms
* Second test runs with a never ending context and tests that reaching the max count will also stop the pinger nicely