### PR TITLE
Set outbound interface, like `ping -I` option

### DIFF
--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -94,7 +94,7 @@ func main() {
 	pinger.Interval = *interval
 	pinger.Timeout = *timeout
 	pinger.TTL = *ttl
-	pinger.Iface = *iface
+	pinger.Interface = *iface
 	pinger.SetPrivileged(*privileged)
 
 	fmt.Printf("PING %s (%s):\n", pinger.Addr(), pinger.IPAddr())

--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -13,7 +13,7 @@ import (
 var usage = `
 Usage:
 
-    ping [-c count] [-i interval] [-t timeout] [--privileged] host
+    ping [-c count] [-i interval] [-t timeout] [-I interface] [--privileged] host
 
 Examples:
 
@@ -29,6 +29,9 @@ Examples:
     # ping google for 10 seconds
     ping -t 10s www.google.com
 
+    # ping google specified interface
+    ping -I eth1 www.goole.com
+
     # Send a privileged raw ICMP ping
     sudo ping --privileged www.google.com
 
@@ -42,6 +45,7 @@ func main() {
 	count := flag.Int("c", -1, "")
 	size := flag.Int("s", 24, "")
 	ttl := flag.Int("l", 64, "TTL")
+	iface := flag.String("I", "", "interface name")
 	privileged := flag.Bool("privileged", false, "")
 	flag.Usage = func() {
 		fmt.Print(usage)
@@ -90,6 +94,7 @@ func main() {
 	pinger.Interval = *interval
 	pinger.Timeout = *timeout
 	pinger.TTL = *ttl
+	pinger.Iface = *iface
 	pinger.SetPrivileged(*privileged)
 
 	fmt.Printf("PING %s (%s):\n", pinger.Addr(), pinger.IPAddr())

--- a/packetconn.go
+++ b/packetconn.go
@@ -18,13 +18,13 @@ type packetConn interface {
 	SetReadDeadline(t time.Time) error
 	WriteTo(b []byte, dst net.Addr) (int, error)
 	SetTTL(ttl int)
-	SetIfaceIndex(ifaceIndex int)
+	SetIfIndex(ifIndex int)
 }
 
 type icmpConn struct {
-	c          *icmp.PacketConn
-	ttl        int
-	ifaceIndex int
+	c       *icmp.PacketConn
+	ttl     int
+	ifIndex int
 }
 
 func (c *icmpConn) Close() error {
@@ -35,8 +35,8 @@ func (c *icmpConn) SetTTL(ttl int) {
 	c.ttl = ttl
 }
 
-func (c *icmpConn) SetIfaceIndex(ifaceIndex int) {
-	c.ifaceIndex = ifaceIndex
+func (c *icmpConn) SetIfIndex(ifIndex int) {
+	c.ifIndex = ifIndex
 }
 
 func (c *icmpConn) SetReadDeadline(t time.Time) error {
@@ -69,12 +69,12 @@ func (c *icmpv4Conn) WriteTo(b []byte, dst net.Addr) (int, error) {
 		return 0, err
 	}
 	var cm *ipv4.ControlMessage
-	if 1 <= c.ifaceIndex {
-		// c.ifaceIndex == 0 if not set interface
+	if 1 <= c.ifIndex {
+		// c.ifIndex == 0 if not set interface
 		if err := c.c.IPv4PacketConn().SetControlMessage(ipv4.FlagInterface, true); err != nil {
 			return 0, err
 		}
-		cm = &ipv4.ControlMessage{IfIndex: c.ifaceIndex}
+		cm = &ipv4.ControlMessage{IfIndex: c.ifIndex}
 	}
 
 	return c.c.IPv4PacketConn().WriteTo(b, cm, dst)
@@ -110,12 +110,12 @@ func (c *icmpV6Conn) WriteTo(b []byte, dst net.Addr) (int, error) {
 		return 0, err
 	}
 	var cm *ipv6.ControlMessage
-	if 1 <= c.ifaceIndex {
-		// c.ifaceIndex == 0 if not set interface
+	if 1 <= c.ifIndex {
+		// c.ifIndex == 0 if not set interface
 		if err := c.c.IPv6PacketConn().SetControlMessage(ipv6.FlagInterface, true); err != nil {
 			return 0, err
 		}
-		cm = &ipv6.ControlMessage{IfIndex: c.ifaceIndex}
+		cm = &ipv6.ControlMessage{IfIndex: c.ifIndex}
 	}
 
 	return c.c.IPv6PacketConn().WriteTo(b, cm, dst)

--- a/ping.go
+++ b/ping.go
@@ -182,8 +182,8 @@ type Pinger struct {
 	// Source is the source IP address
 	Source string
 
-	// Iface used to send/recv ICMP messages
-	Iface string
+	// Interface used to send/recv ICMP messages
+	Interface string
 
 	// Channel and mutex used to communicate when the Pinger should stop between goroutines.
 	done chan interface{}
@@ -429,12 +429,12 @@ func (p *Pinger) RunWithContext(ctx context.Context) error {
 	defer conn.Close()
 
 	conn.SetTTL(p.TTL)
-	if p.Iface != "" {
-		iface, err := net.InterfaceByName(p.Iface)
+	if p.Interface != "" {
+		iface, err := net.InterfaceByName(p.Interface)
 		if err != nil {
 			return err
 		}
-		conn.SetIfaceIndex(iface.Index)
+		conn.SetIfIndex(iface.Index)
 	}
 	return p.run(ctx, conn)
 }

--- a/ping.go
+++ b/ping.go
@@ -182,6 +182,9 @@ type Pinger struct {
 	// Source is the source IP address
 	Source string
 
+	// Iface used to send/recv ICMP messages
+	Iface string
+
 	// Channel and mutex used to communicate when the Pinger should stop between goroutines.
 	done chan interface{}
 	lock sync.Mutex
@@ -426,6 +429,13 @@ func (p *Pinger) RunWithContext(ctx context.Context) error {
 	defer conn.Close()
 
 	conn.SetTTL(p.TTL)
+	if p.Iface != "" {
+		iface, err := net.InterfaceByName(p.Iface)
+		if err != nil {
+			return err
+		}
+		conn.SetIfaceIndex(iface.Index)
+	}
 	return p.run(ctx, conn)
 }
 

--- a/ping_test.go
+++ b/ping_test.go
@@ -478,13 +478,13 @@ func TestStatisticsLossy(t *testing.T) {
 	}
 }
 
-func TestSetIfaceName(t *testing.T) {
+func TestSetInterfaceName(t *testing.T) {
 	pinger := New("localhost")
 	pinger.Count = 1
 	pinger.Timeout = time.Second
 
 	// Set loopback interface
-	pinger.Iface = "lo"
+	pinger.Interface = "lo"
 	err := pinger.Run()
 	if runtime.GOOS == "linux" {
 		AssertNoError(t, err)
@@ -493,7 +493,7 @@ func TestSetIfaceName(t *testing.T) {
 	}
 
 	// Set fake interface
-	pinger.Iface = "L()0pB@cK"
+	pinger.Interface = "L()0pB@cK"
 	err = pinger.Run()
 	AssertError(t, err, "device not found")
 }
@@ -664,7 +664,7 @@ func (c testPacketConn) ICMPRequestType() icmp.Type        { return ipv4.ICMPTyp
 func (c testPacketConn) SetFlagTTL() error                 { return nil }
 func (c testPacketConn) SetReadDeadline(t time.Time) error { return nil }
 func (c testPacketConn) SetTTL(t int)                      {}
-func (c testPacketConn) SetIfaceIndex(t int)               {}
+func (c testPacketConn) SetIfIndex(ifIndex int)            {}
 
 func (c testPacketConn) ReadFrom(b []byte) (n int, ttl int, src net.Addr, err error) {
 	return 0, 0, nil, nil


### PR DESCRIPTION
Hello,

I attempted to implement a useful feature - sending data packets from a specific network interface, similar to what the "ping" command's "-I" option does in Linux.
Hoping I did it correctly. Test successfully passed on Linux OS.

Thanks!

The issues related to this feature:

go-ping/ping#111

go-ping/ping#204