### PR TITLE
Add support for setting SO_MARK socket option on outgoing ICMP packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ See [this blog](https://sturmflut.github.io/linux/ubuntu/2015/01/17/unprivileged
 and the Go [x/net/icmp](https://godoc.org/golang.org/x/net/icmp) package
 for more details.
 
+This library also supports setting the `SO_MARK` socket option which is equivalent to the `-m mark`
+flag in standard ping binaries on linux. Setting this option requires the `CAP_NET_ADMIN` capability
+(via `setcap` or elevated privileges). You can set a mark (ex: 100) with `pinger.SetMark(100)` in your code.
+
 ### Windows
 
 You must use `pinger.SetPrivileged(true)`, otherwise you will receive

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ See [this blog](https://sturmflut.github.io/linux/ubuntu/2015/01/17/unprivileged
 and the Go [x/net/icmp](https://godoc.org/golang.org/x/net/icmp) package
 for more details.
 
-This library also supports setting the `SO_MARK` socket option which is equivalent to the `-m mark`
+This library supports setting the `SO_MARK` socket option which is equivalent to the `-m mark`
 flag in standard ping binaries on linux. Setting this option requires the `CAP_NET_ADMIN` capability
 (via `setcap` or elevated privileges). You can set a mark (ex: 100) with `pinger.SetMark(100)` in your code.
 

--- a/packetconn.go
+++ b/packetconn.go
@@ -18,6 +18,7 @@ type packetConn interface {
 	SetReadDeadline(t time.Time) error
 	WriteTo(b []byte, dst net.Addr) (int, error)
 	SetTTL(ttl int)
+	SetMark(m uint) error
 }
 
 type icmpConn struct {

--- a/ping.go
+++ b/ping.go
@@ -82,6 +82,8 @@ const (
 var (
 	ipv4Proto = map[string]string{"icmp": "ip4:icmp", "udp": "udp4"}
 	ipv6Proto = map[string]string{"icmp": "ip6:ipv6-icmp", "udp": "udp6"}
+
+	ErrMarkNotSupported = errors.New("setting SO_MARK socket option is not supported on this platform")
 )
 
 // New returns a new Pinger struct pointer.
@@ -189,7 +191,7 @@ type Pinger struct {
 	ipaddr *net.IPAddr
 	addr   string
 
-	// Mark is a mark (fwmark) set on outgoing icmp packets
+	// mark is a SO_MARK (fwmark) set on outgoing icmp packets
 	mark uint
 
 	// trackerUUIDs is the list of UUIDs being used for sending packets.

--- a/ping.go
+++ b/ping.go
@@ -189,6 +189,9 @@ type Pinger struct {
 	ipaddr *net.IPAddr
 	addr   string
 
+	// Mark is a mark (fwmark) set on outgoing icmp packets
+	mark uint
+
 	// trackerUUIDs is the list of UUIDs being used for sending packets.
 	trackerUUIDs []uuid.UUID
 
@@ -398,6 +401,16 @@ func (p *Pinger) ID() int {
 	return p.id
 }
 
+// SetMark sets a mark intended to be set on outgoing ICMP packets.
+func (p *Pinger) SetMark(m uint) {
+	p.mark = m
+}
+
+// Mark returns the mark to be set on outgoing ICMP packets.
+func (p *Pinger) Mark() uint {
+	return p.mark
+}
+
 // Run runs the pinger. This is a blocking function that will exit when it's
 // done. If Count or Interval are not specified, it will run continuously until
 // it is interrupted.
@@ -424,6 +437,12 @@ func (p *Pinger) RunWithContext(ctx context.Context) error {
 		return err
 	}
 	defer conn.Close()
+
+	if p.mark != 0 {
+		if err := conn.SetMark(p.mark); err != nil {
+			return fmt.Errorf("error setting mark: %v", err)
+		}
+	}
 
 	conn.SetTTL(p.TTL)
 	return p.run(ctx, conn)

--- a/ping_test.go
+++ b/ping_test.go
@@ -643,6 +643,7 @@ func (c testPacketConn) ICMPRequestType() icmp.Type        { return ipv4.ICMPTyp
 func (c testPacketConn) SetFlagTTL() error                 { return nil }
 func (c testPacketConn) SetReadDeadline(t time.Time) error { return nil }
 func (c testPacketConn) SetTTL(t int)                      {}
+func (c testPacketConn) SetMark(m uint) error              { return nil }
 
 func (c testPacketConn) ReadFrom(b []byte) (n int, ttl int, src net.Addr, err error) {
 	return 0, 0, nil, nil

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -3,6 +3,15 @@
 
 package probing
 
+import (
+	"errors"
+	"os"
+	"reflect"
+	"syscall"
+
+	"golang.org/x/net/icmp"
+)
+
 // Returns the length of an ICMP message.
 func (p *Pinger) getMessageLength() int {
 	return p.Size + 8
@@ -12,9 +21,66 @@ func (p *Pinger) getMessageLength() int {
 func (p *Pinger) matchID(ID int) bool {
 	// On Linux we can only match ID if we are privileged.
 	if p.protocol == "icmp" {
-		if ID != p.id {
-			return false
-		}
+		return ID == p.id
 	}
 	return true
+}
+
+// SetMark sets the SO_MARK socket option on outgoing ICMP packets.
+// Setting this option requires CAP_NET_ADMIN.
+func (c *icmpConn) SetMark(mark uint) error {
+	fd, err := getFD(c.c)
+	if err != nil {
+		return err
+	}
+	return os.NewSyscallError(
+		"setsockopt",
+		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_MARK, int(mark)),
+	)
+}
+
+// SetMark sets the SO_MARK socket option on outgoing ICMP packets.
+// Setting this option requires CAP_NET_ADMIN.
+func (c *icmpv4Conn) SetMark(mark uint) error {
+	fd, err := getFD(c.icmpConn.c)
+	if err != nil {
+		return err
+	}
+	return os.NewSyscallError(
+		"setsockopt",
+		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_MARK, int(mark)),
+	)
+}
+
+// SetMark sets the SO_MARK socket option on outgoing ICMP packets.
+// Setting this option requires CAP_NET_ADMIN.
+func (c *icmpV6Conn) SetMark(mark uint) error {
+	fd, err := getFD(c.icmpConn.c)
+	if err != nil {
+		return err
+	}
+	return os.NewSyscallError(
+		"setsockopt",
+		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_MARK, int(mark)),
+	)
+}
+
+// getFD gets the system file descriptor for an icmp.PacketConn
+func getFD(c *icmp.PacketConn) (uintptr, error) {
+	v := reflect.ValueOf(c).Elem().FieldByName("c").Elem()
+	if v.Elem().Kind() != reflect.Struct {
+		return 0, errors.New("invalid type")
+	}
+
+	fd := v.Elem().FieldByName("conn").FieldByName("fd")
+	if fd.Elem().Kind() != reflect.Struct {
+		return 0, errors.New("invalid type")
+	}
+
+	pfd := fd.Elem().FieldByName("pfd")
+	if pfd.Kind() != reflect.Struct {
+		return 0, errors.New("invalid type")
+	}
+
+	return uintptr(pfd.FieldByName("Sysfd").Int()), nil
 }

--- a/utils_other.go
+++ b/utils_other.go
@@ -3,6 +3,10 @@
 
 package probing
 
+import (
+	"errors"
+)
+
 // Returns the length of an ICMP message.
 func (p *Pinger) getMessageLength() int {
 	return p.Size + 8
@@ -10,8 +14,23 @@ func (p *Pinger) getMessageLength() int {
 
 // Attempts to match the ID of an ICMP packet.
 func (p *Pinger) matchID(ID int) bool {
-	if ID != p.id {
-		return false
-	}
-	return true
+	return ID == p.id
+}
+
+// SetMark sets the SO_MARK socket option on outgoing ICMP packets.
+// Setting this option requires CAP_NET_ADMIN.
+func (c *icmpConn) SetMark(mark uint) error {
+	return errors.New("setting SO_MARK socket option is not supported on this platform")
+}
+
+// SetMark sets the SO_MARK socket option on outgoing ICMP packets.
+// Setting this option requires CAP_NET_ADMIN.
+func (c *icmpv4Conn) SetMark(mark uint) error {
+	return errors.New("setting SO_MARK socket option is not supported on this platform")
+}
+
+// SetMark sets the SO_MARK socket option on outgoing ICMP packets.
+// Setting this option requires CAP_NET_ADMIN.
+func (c *icmpV6Conn) SetMark(mark uint) error {
+	return errors.New("setting SO_MARK socket option is not supported on this platform")
 }

--- a/utils_other.go
+++ b/utils_other.go
@@ -3,10 +3,6 @@
 
 package probing
 
-import (
-	"errors"
-)
-
 // Returns the length of an ICMP message.
 func (p *Pinger) getMessageLength() int {
 	return p.Size + 8
@@ -20,17 +16,17 @@ func (p *Pinger) matchID(ID int) bool {
 // SetMark sets the SO_MARK socket option on outgoing ICMP packets.
 // Setting this option requires CAP_NET_ADMIN.
 func (c *icmpConn) SetMark(mark uint) error {
-	return errors.New("setting SO_MARK socket option is not supported on this platform")
+	return ErrMarkNotSupported
 }
 
 // SetMark sets the SO_MARK socket option on outgoing ICMP packets.
 // Setting this option requires CAP_NET_ADMIN.
 func (c *icmpv4Conn) SetMark(mark uint) error {
-	return errors.New("setting SO_MARK socket option is not supported on this platform")
+	return ErrMarkNotSupported
 }
 
 // SetMark sets the SO_MARK socket option on outgoing ICMP packets.
 // Setting this option requires CAP_NET_ADMIN.
 func (c *icmpV6Conn) SetMark(mark uint) error {
-	return errors.New("setting SO_MARK socket option is not supported on this platform")
+	return ErrMarkNotSupported
 }

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -4,8 +4,6 @@
 package probing
 
 import (
-	"errors"
-
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
 )
@@ -29,17 +27,17 @@ func (p *Pinger) matchID(ID int) bool {
 // SetMark sets the SO_MARK socket option on outgoing ICMP packets.
 // Setting this option requires CAP_NET_ADMIN.
 func (c *icmpConn) SetMark(mark uint) error {
-	return errors.New("setting SO_MARK socket option is not supported on this platform")
+	return ErrMarkNotSupported
 }
 
 // SetMark sets the SO_MARK socket option on outgoing ICMP packets.
 // Setting this option requires CAP_NET_ADMIN.
 func (c *icmpv4Conn) SetMark(mark uint) error {
-	return errors.New("setting SO_MARK socket option is not supported on this platform")
+	return ErrMarkNotSupported
 }
 
 // SetMark sets the SO_MARK socket option on outgoing ICMP packets.
 // Setting this option requires CAP_NET_ADMIN.
 func (c *icmpV6Conn) SetMark(mark uint) error {
-	return errors.New("setting SO_MARK socket option is not supported on this platform")
+	return ErrMarkNotSupported
 }

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -4,6 +4,8 @@
 package probing
 
 import (
+	"errors"
+
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
 )
@@ -22,4 +24,22 @@ func (p *Pinger) matchID(ID int) bool {
 		return false
 	}
 	return true
+}
+
+// SetMark sets the SO_MARK socket option on outgoing ICMP packets.
+// Setting this option requires CAP_NET_ADMIN.
+func (c *icmpConn) SetMark(mark uint) error {
+	return errors.New("setting SO_MARK socket option is not supported on this platform")
+}
+
+// SetMark sets the SO_MARK socket option on outgoing ICMP packets.
+// Setting this option requires CAP_NET_ADMIN.
+func (c *icmpv4Conn) SetMark(mark uint) error {
+	return errors.New("setting SO_MARK socket option is not supported on this platform")
+}
+
+// SetMark sets the SO_MARK socket option on outgoing ICMP packets.
+// Setting this option requires CAP_NET_ADMIN.
+func (c *icmpV6Conn) SetMark(mark uint) error {
+	return errors.New("setting SO_MARK socket option is not supported on this platform")
 }


### PR DESCRIPTION
The standard ping utility in linux has a flag that can be used to set a mark on outgoing packets which is used in tandem with linux policy routing.

```
-m mark
           use mark to tag the packets going out. This is useful for variety of reasons within the kernel such as
           using policy routing to select specific outbound processing.
```

Setting a mark can be achieved in linux by setting the `SO_MARK` socket option:

```
       SO_MARK (since Linux 2.6.25)
              Set the mark for each packet sent through this socket
              (similar to the netfilter MARK target but socket-based).
              Changing the mark can be used for mark-based routing
              without netfilter or for packet filtering.  Setting this
              option requires the CAP_NET_ADMIN capability.
```

This PR attempts to adds support for this feature. Given a socket has to first exist before we can set the mark we add a `SetMark()` and `Mark()` options to set and read the intended mark to be set once the icmp conn exists. In addition to this we add a `SetMark()` method to the packetconn interface to actually set the socket option after the conn is created. This PR only attempts to set this option under linux. Other environments (windows, etc.) will throw an error if attempting to set a mark on the socket. I'm not sure if this is supported outside of linux or not.