### PR TITLE
Workaround unprivileged PacketConn on darwin returns the entire IP packet in icmp.ListenPacket()

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -60,6 +60,7 @@ import (
 	"math"
 	"math/rand"
 	"net"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -591,12 +592,18 @@ func (p *Pinger) recvICMP(
 	expBackoff := newExpBackoff(50*time.Microsecond, 11)
 	delay := expBackoff.Get()
 
+	// Workaround for https://github.com/golang/go/issues/47369
+	offset := 0
+	if p.ipv4 && !p.Privileged() && runtime.GOOS == "darwin" {
+		offset = 20
+	}
+
 	for {
 		select {
 		case <-p.done:
 			return nil
 		default:
-			bytes := make([]byte, p.getMessageLength())
+			bytes := make([]byte, p.getMessageLength()+offset)
 			if err := conn.SetReadDeadline(time.Now().Add(delay)); err != nil {
 				return err
 			}
@@ -649,6 +656,8 @@ func (p *Pinger) processPacket(recv *packet) error {
 	var proto int
 	if p.ipv4 {
 		proto = protocolICMP
+		// Workaround for https://github.com/golang/go/issues/47369
+		recv.nbytes = stripIPv4Header(recv.nbytes, recv.bytes)
 	} else {
 		proto = protocolIPv6ICMP
 	}
@@ -833,4 +842,21 @@ var seed = time.Now().UnixNano()
 // getSeed returns a goroutine-safe unique seed
 func getSeed() int64 {
 	return atomic.AddInt64(&seed, 1)
+}
+
+// stripIPv4Header strips IPv4 header bytes if present
+// https://github.com/golang/go/commit/3b5be4522a21df8ce52a06a0c4ba005c89a8590f
+func stripIPv4Header(n int, b []byte) int {
+	if len(b) < 20 {
+		return n
+	}
+	l := int(b[0]&0x0f) << 2
+	if 20 > l || l > len(b) {
+		return n
+	}
+	if b[0]>>4 != 4 {
+		return n
+	}
+	copy(b, b[l:])
+	return n - l
 }


### PR DESCRIPTION
TLDR: unprivileged icmp echo replies are discarded on macOS (darwin)

This is a patch to work around an issue described in https://github.com/golang/go/issues/47369 which can be summarized as follows:

Due to [setting the IP_STRPHDR socket option](https://cs.opensource.google/go/x/net/+/refs/tags/v0.10.0:icmp/listen_posix.go;l=74-75;bpv=0;bpt=0) in darwin  (macOS) environments, 
reads on unprivileged sockets (udp) include the IP header before the ICMP header in the read bytes returned by `icmp.ListenPacket()`.  As a result of this, `pro-bing` ends up [discarding](https://github.com/prometheus-community/pro-bing/blob/a17ba032a911c7afdd16c0ef39278e603f2614b8/ping.go#L662-L664) icmp echo replies due to the unexpected ip header bytes returned by `icmp.ListenPacket()`.

While this problem needs to be addressed in go itself, this patch provides a work around until this issue is addressed.

