### PR TITLE
Add support for setting do-not-fragment bit (linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ This library supports setting the `SO_MARK` socket option which is equivalent to
 flag in standard ping binaries on linux. Setting this option requires the `CAP_NET_ADMIN` capability
 (via `setcap` or elevated privileges). You can set a mark (ex: 100) with `pinger.SetMark(100)` in your code.
 
+Setting the "Don't Fragment" bit is supported under Linux which is equivalent to `ping -Mdo`.
+You can enable this with `pinger.SetDoNotFragment(true)`.
+
 ### Windows
 
 You must use `pinger.SetPrivileged(true)`, otherwise you will receive

--- a/packetconn.go
+++ b/packetconn.go
@@ -19,6 +19,7 @@ type packetConn interface {
 	WriteTo(b []byte, dst net.Addr) (int, error)
 	SetTTL(ttl int)
 	SetMark(m uint) error
+	SetDoNotFragment() error
 }
 
 type icmpConn struct {

--- a/ping.go
+++ b/ping.go
@@ -85,6 +85,7 @@ var (
 	ipv6Proto = map[string]string{"icmp": "ip6:ipv6-icmp", "udp": "udp6"}
 
 	ErrMarkNotSupported = errors.New("setting SO_MARK socket option is not supported on this platform")
+	ErrDFNotSupported   = errors.New("setting do-not-fragment bit is not supported on this platform")
 )
 
 // New returns a new Pinger struct pointer.
@@ -194,6 +195,9 @@ type Pinger struct {
 
 	// mark is a SO_MARK (fwmark) set on outgoing icmp packets
 	mark uint
+
+	// df when true sets the do-not-fragment bit in the outer IP or IPv6 header
+	df bool
 
 	// trackerUUIDs is the list of UUIDs being used for sending packets.
 	trackerUUIDs []uuid.UUID
@@ -414,6 +418,11 @@ func (p *Pinger) Mark() uint {
 	return p.mark
 }
 
+// SetDoNotFragment sets the do-not-fragment bit in the outer IP header to the desired value.
+func (p *Pinger) SetDoNotFragment(df bool) {
+	p.df = df
+}
+
 // Run runs the pinger. This is a blocking function that will exit when it's
 // done. If Count or Interval are not specified, it will run continuously until
 // it is interrupted.
@@ -444,6 +453,12 @@ func (p *Pinger) RunWithContext(ctx context.Context) error {
 	if p.mark != 0 {
 		if err := conn.SetMark(p.mark); err != nil {
 			return fmt.Errorf("error setting mark: %v", err)
+		}
+	}
+
+	if p.df {
+		if err := conn.SetDoNotFragment(); err != nil {
+			return fmt.Errorf("error setting do-not-fragment: %v", err)
 		}
 	}
 

--- a/ping_test.go
+++ b/ping_test.go
@@ -644,6 +644,7 @@ func (c testPacketConn) SetFlagTTL() error                 { return nil }
 func (c testPacketConn) SetReadDeadline(t time.Time) error { return nil }
 func (c testPacketConn) SetTTL(t int)                      {}
 func (c testPacketConn) SetMark(m uint) error              { return nil }
+func (c testPacketConn) SetDoNotFragment() error           { return nil }
 
 func (c testPacketConn) ReadFrom(b []byte) (n int, ttl int, src net.Addr, err error) {
 	return 0, 0, nil, nil

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -65,6 +65,42 @@ func (c *icmpV6Conn) SetMark(mark uint) error {
 	)
 }
 
+// SetDoNotFragment sets the do-not-fragment bit in the IP header of outgoing ICMP packets.
+func (c *icmpConn) SetDoNotFragment() error {
+	fd, err := getFD(c.c)
+	if err != nil {
+		return err
+	}
+	return os.NewSyscallError(
+		"setsockopt",
+		syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_MTU_DISCOVER, syscall.IP_PMTUDISC_DO),
+	)
+}
+
+// SetDoNotFragment sets the do-not-fragment bit in the IP header of outgoing ICMP packets.
+func (c *icmpv4Conn) SetDoNotFragment() error {
+	fd, err := getFD(c.icmpConn.c)
+	if err != nil {
+		return err
+	}
+	return os.NewSyscallError(
+		"setsockopt",
+		syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_MTU_DISCOVER, syscall.IP_PMTUDISC_DO),
+	)
+}
+
+// SetDoNotFragment sets the do-not-fragment bit in the IPv6 header of outgoing ICMPv6 packets.
+func (c *icmpV6Conn) SetDoNotFragment() error {
+	fd, err := getFD(c.icmpConn.c)
+	if err != nil {
+		return err
+	}
+	return os.NewSyscallError(
+		"setsockopt",
+		syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IPV6, syscall.IPV6_MTU_DISCOVER, syscall.IP_PMTUDISC_DO),
+	)
+}
+
 // getFD gets the system file descriptor for an icmp.PacketConn
 func getFD(c *icmp.PacketConn) (uintptr, error) {
 	v := reflect.ValueOf(c).Elem().FieldByName("c").Elem()

--- a/utils_other.go
+++ b/utils_other.go
@@ -30,3 +30,18 @@ func (c *icmpv4Conn) SetMark(mark uint) error {
 func (c *icmpV6Conn) SetMark(mark uint) error {
 	return ErrMarkNotSupported
 }
+
+// SetDoNotFragment sets the do-not-fragment bit in the IP header of outgoing ICMP packets.
+func (c *icmpConn) SetDoNotFragment() error {
+	return ErrDFNotSupported
+}
+
+// SetDoNotFragment sets the do-not-fragment bit in the IP header of outgoing ICMP packets.
+func (c *icmpv4Conn) SetDoNotFragment() error {
+	return ErrDFNotSupported
+}
+
+// SetDoNotFragment sets the do-not-fragment bit in the IPv6 header of outgoing ICMPv6 packets.
+func (c *icmpV6Conn) SetDoNotFragment() error {
+	return ErrDFNotSupported
+}

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -41,3 +41,18 @@ func (c *icmpv4Conn) SetMark(mark uint) error {
 func (c *icmpV6Conn) SetMark(mark uint) error {
 	return ErrMarkNotSupported
 }
+
+// SetDoNotFragment sets the do-not-fragment bit in the IP header of outgoing ICMP packets.
+func (c *icmpConn) SetDoNotFragment() error {
+	return ErrDFNotSupported
+}
+
+// SetDoNotFragment sets the do-not-fragment bit in the IP header of outgoing ICMP packets.
+func (c *icmpv4Conn) SetDoNotFragment() error {
+	return ErrDFNotSupported
+}
+
+// SetDoNotFragment sets the do-not-fragment bit in the IPv6 header of outgoing ICMPv6 packets.
+func (c *icmpV6Conn) SetDoNotFragment() error {
+	return ErrDFNotSupported
+}


### PR DESCRIPTION
Closes #23 

This PR only attempts to add support for this in linux. It seems it may be feasible to add support for this under [windows](https://github.com/quic-go/quic-go/blob/f401a73d271b76a353313de227fb19ff53a8bedd/sys_conn_df_windows.go#L14-L41) but I do not have any way of testing this easily so for now this will be omitted. Other platforms I could not get this working as the socket options required to do this are unclear under BSD platforms (for example) but it may be possible to support this after a little more r&d.

I tested using:

```
pinger.Size = 1472
pinger.SetDoNotFragment(true)
```

Which yielded a 1500 byte IP packet (my IP MTU is 1500) per tcpdump on the wire:
```
12:32:09.158203 IP 10.10.0.50 > 10.10.0.1: ICMP echo request, id 39, seq 0, length 1480
```

Doing the same as the above but setting `pinger.Size = 1473` we get the following error from the kernel which is what we expect to see with do-not-fragment set: 
```
sendto: message too long
```



