### PR TITLE
Add support for OnSendError and OnRecvError handlers

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -651,8 +651,8 @@ func (p *Pinger) recvICMP(
 			var err error
 			n, ttl, _, err = conn.ReadFrom(bytes)
 			if err != nil {
-				if handler := p.OnRecvError; handler != nil {
-					handler(err)
+				if p.OnRecvError != nil {
+					p.OnRecvError(err)
 				}
 				if neterr, ok := err.(*net.OpError); ok {
 					if neterr.Timeout() {
@@ -801,7 +801,7 @@ func (p *Pinger) sendICMP(conn packetConn) error {
 
 	for {
 		if _, err := conn.WriteTo(msgBytes, dst); err != nil {
-			if handler := p.OnSendError; handler != nil {
+			if p.OnSendError != nil {
 				outPkt := &Packet{
 					Nbytes: len(msgBytes),
 					IPAddr: p.ipaddr,
@@ -809,7 +809,7 @@ func (p *Pinger) sendICMP(conn packetConn) error {
 					Seq:    p.sequence,
 					ID:     p.id,
 				}
-				handler(outPkt, err)
+				p.OnSendError(outPkt, err)
 			}
 			if neterr, ok := err.(*net.OpError); ok {
 				if neterr.Err == syscall.ENOBUFS {

--- a/ping.go
+++ b/ping.go
@@ -177,6 +177,12 @@ type Pinger struct {
 	// OnDuplicateRecv is called when a packet is received that has already been received.
 	OnDuplicateRecv func(*Packet)
 
+	// OnSendError is called when an error occurs while Pinger attempts to send a packet
+	OnSendError func(*Packet, error)
+
+	// OnRecvError is called when an error occurs while Pinger attempts to receive a packet
+	OnRecvError func(error)
+
 	// Size of packet being sent
 	Size int
 
@@ -645,6 +651,9 @@ func (p *Pinger) recvICMP(
 			var err error
 			n, ttl, _, err = conn.ReadFrom(bytes)
 			if err != nil {
+				if handler := p.OnRecvError; handler != nil {
+					handler(err)
+				}
 				if neterr, ok := err.(*net.OpError); ok {
 					if neterr.Timeout() {
 						// Read timeout
@@ -792,6 +801,16 @@ func (p *Pinger) sendICMP(conn packetConn) error {
 
 	for {
 		if _, err := conn.WriteTo(msgBytes, dst); err != nil {
+			if handler := p.OnSendError; handler != nil {
+				outPkt := &Packet{
+					Nbytes: len(msgBytes),
+					IPAddr: p.ipaddr,
+					Addr:   p.addr,
+					Seq:    p.sequence,
+					ID:     p.id,
+				}
+				handler(outPkt, err)
+			}
 			if neterr, ok := err.(*net.OpError); ok {
 				if neterr.Err == syscall.ENOBUFS {
 					continue


### PR DESCRIPTION
Following on to discussion in https://github.com/prometheus-community/pro-bing/pull/40#issuecomment-1563213985 I would like to propose an alternative based on comments from @SuperQ for adding send and receive packet error handlers.

For my own use case this would allow to optionally receive error signals in callback functions and terminate (`pinger.Stop()`) a running ping under certain error conditions without altering the behavior of this library in terms of its existing error handling (which is basically just logging the error and continuing at present). The only difference between the two error handlers is that `OnSendError()` sends both info for the packet that Pinger was attempting to send and the error that was returned, while `OnRecvError()` only sends the error. The reason for this is due to receive errors are generally related to packets that cannot be read and thus we do not have packet details, while in the sending case we have this information available. I'm open to renaming these functions to something like `OnSendPacketError()` if that makes it more obvious that we get packet details with that specific callback.