### PR TITLE
Adds support for timeout per packet

### DIFF
--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -38,6 +38,7 @@ Examples:
 
 func main() {
 	timeout := flag.Duration("t", time.Second*100000, "")
+	packetTimeout := flag.Duration("p", 0, "")
 	interval := flag.Duration("i", time.Second, "")
 	count := flag.Int("c", -1, "")
 	size := flag.Int("s", 24, "")
@@ -89,6 +90,7 @@ func main() {
 	pinger.Size = *size
 	pinger.Interval = *interval
 	pinger.Timeout = *timeout
+	pinger.PacketTimeout = *packetTimeout
 	pinger.TTL = *ttl
 	pinger.SetPrivileged(*privileged)
 

--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -71,8 +71,13 @@ func main() {
 	}()
 
 	pinger.OnRecv = func(pkt *probing.Packet) {
-		fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v ttl=%v\n",
-			pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt, pkt.TTL)
+		if pkt.Rtt > *packetTimeout {
+			fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v ttl=%v <timed out>\n",
+				pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt, pkt.TTL)
+		} else {
+			fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v ttl=%v\n",
+				pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt, pkt.TTL)
+		}
 	}
 	pinger.OnDuplicateRecv = func(pkt *probing.Packet) {
 		fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v ttl=%v (DUP!)\n",


### PR DESCRIPTION
This is an attempt at solving the [timeout per packet issue ](https://github.com/prometheus-community/pro-bing/issues/19)using the rtt field.
The timeout timer is set to the lower value of request timeout / last packet sent timeout so that the pinger exits as soons as there is no more work to do.

Please have a look and share your thoughts.