### PR TITLE
add timeout handler

### DIFF
--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -38,6 +38,7 @@ Examples:
 
 func main() {
 	timeout := flag.Duration("t", time.Second*100000, "")
+	maxRtt := flag.Duration("mr", time.Second*3, "")
 	interval := flag.Duration("i", time.Second, "")
 	count := flag.Int("c", -1, "")
 	size := flag.Int("s", 24, "")
@@ -84,11 +85,15 @@ func main() {
 		fmt.Printf("round-trip min/avg/max/stddev = %v/%v/%v/%v\n",
 			stats.MinRtt, stats.AvgRtt, stats.MaxRtt, stats.StdDevRtt)
 	}
+	pinger.OnTimeOut = func(packet *probing.Packet) {
+		fmt.Println("timeout", packet.Addr, packet.Rtt, packet.TTL)
+	}
 
 	pinger.Count = *count
 	pinger.Size = *size
 	pinger.Interval = *interval
 	pinger.Timeout = *timeout
+	pinger.MaxRtt = *maxRtt
 	pinger.TTL = *ttl
 	pinger.SetPrivileged(*privileged)
 

--- a/ping_test.go
+++ b/ping_test.go
@@ -29,7 +29,8 @@ func TestProcessPacket(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to marshal UUID binary: %s", err)
 	}
-	data := append(timeToBytes(time.Now()), uuidEncoded...)
+	now := time.Now()
+	data := append(timeToBytes(now), uuidEncoded...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		data = append(data, bytes.Repeat([]byte{1}, remainSize)...)
 	}
@@ -39,7 +40,8 @@ func TestProcessPacket(t *testing.T) {
 		Seq:  pinger.sequence,
 		Data: data,
 	}
-	pinger.awaitingSequences[currentUUID][pinger.sequence] = struct{}{}
+	pinger.awaitingSequences.putElem(currentUUID, pinger.sequence, now)
+	//pinger.awaitingSequences[currentUUID][pinger.sequence] = struct{}{}
 
 	msg := &icmp.Message{
 		Type: ipv4.ICMPTypeEchoReply,
@@ -598,7 +600,8 @@ func TestProcessPacket_IgnoresDuplicateSequence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to marshal UUID binary: %s", err)
 	}
-	data := append(timeToBytes(time.Now()), uuidEncoded...)
+	now := time.Now()
+	data := append(timeToBytes(now), uuidEncoded...)
 	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
 		data = append(data, bytes.Repeat([]byte{1}, remainSize)...)
 	}
@@ -609,7 +612,9 @@ func TestProcessPacket_IgnoresDuplicateSequence(t *testing.T) {
 		Data: data,
 	}
 	// register the sequence as sent
-	pinger.awaitingSequences[currentUUID][0] = struct{}{}
+
+	pinger.awaitingSequences.putElem(currentUUID, 0, now)
+	//pinger.awaitingSequences[currentUUID][0] = struct{}{}
 
 	msg := &icmp.Message{
 		Type: ipv4.ICMPTypeEchoReply,

--- a/seq_map.go
+++ b/seq_map.go
@@ -1,0 +1,70 @@
+package probing
+
+import (
+	"github.com/google/uuid"
+	"time"
+)
+
+type seqMap struct {
+	trackerUUIDs []uuid.UUID
+	head         *elem
+	tail         *elem
+	seqMap       map[uuid.UUID]map[int]*elem
+}
+type elem struct {
+	uuid uuid.UUID
+	seq  int
+	time time.Time
+	prev *elem
+	next *elem
+}
+
+func newSeqMap(u uuid.UUID) seqMap {
+	s := seqMap{
+		head:   &elem{},
+		tail:   &elem{},
+		seqMap: map[uuid.UUID]map[int]*elem{},
+	}
+	s.trackerUUIDs = append(s.trackerUUIDs, u)
+	s.seqMap[u] = make(map[int]*elem)
+	s.head.next = s.tail
+	s.tail.prev = s.head
+	return s
+}
+
+func (s seqMap) newSeqMap(u uuid.UUID) {
+	s.trackerUUIDs = append(s.trackerUUIDs, u)
+	s.seqMap[u] = make(map[int]*elem)
+	s.head.next = s.tail
+	s.tail.prev = s.head
+}
+
+func (s seqMap) putElem(uuid uuid.UUID, seq int, now time.Time) {
+	e := &elem{
+		uuid: uuid,
+		seq:  seq,
+		time: now,
+		prev: s.tail.prev,
+		next: s.tail,
+	}
+	s.tail.prev.next = e
+	s.tail.prev = e
+	s.seqMap[uuid][seq] = e
+}
+func (s seqMap) getElem(uuid uuid.UUID, seq int) (*elem, bool) {
+	e, ok := s.seqMap[uuid][seq]
+	return e, ok
+}
+func (s seqMap) removeElem(e *elem) {
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	if m, ok := s.seqMap[e.uuid]; ok {
+		delete(m, e.seq)
+	}
+}
+func (s seqMap) peekFirst() *elem {
+	if s.head.next == s.tail {
+		return nil
+	}
+	return s.head.next
+}

--- a/seq_map_test.go
+++ b/seq_map_test.go
@@ -1,0 +1,95 @@
+package probing
+
+import (
+	"github.com/google/uuid"
+	"testing"
+	"time"
+)
+
+func TestSeqMap(t *testing.T) {
+	u := uuid.New()
+	s := newSeqMap(u)
+	t.Run("newSeqMap", func(t *testing.T) {
+		u2 := uuid.New()
+		s.newSeqMap(u2)
+
+		if len(s.trackerUUIDs) != 1 {
+			t.Errorf("Expected length of trackerUUIDs to be 2, got %d", len(s.trackerUUIDs))
+		}
+
+		if _, ok := s.seqMap[u2]; !ok {
+			t.Errorf("Expected seqMap to contain UUID %s", u2.String())
+		}
+	})
+
+	t.Run("putElem", func(t *testing.T) {
+		seq := 1
+		s.putElem(u, seq, time.Now())
+
+		// 检查 seqMap 中是否包含正确的元素
+		if _, ok := s.seqMap[u][seq]; !ok {
+			t.Errorf("Expected seqMap[%s][%d] to exist", u.String(), seq)
+		}
+
+		if s.peekFirst().seq != seq {
+			t.Errorf("Expected tail.prev.seq to be %d, got %d", seq, s.tail.prev.seq)
+		}
+	})
+
+	t.Run("getElem", func(t *testing.T) {
+		seq := 1
+		elem, ok := s.getElem(u, seq)
+
+		if !ok {
+			t.Errorf("Expected getElem to return true for existing element")
+		}
+
+		if elem.seq != seq {
+			t.Errorf("Expected element's seq to be %d, got %d", seq, elem.seq)
+		}
+	})
+
+	t.Run("removeElem", func(t *testing.T) {
+		seq := 1
+		elem, ok := s.getElem(u, seq)
+		if !ok {
+			t.Fatalf("Expected getElem to return true for existing element")
+		}
+
+		s.removeElem(elem)
+
+		if _, ok := s.seqMap[u][seq]; ok {
+			t.Errorf("Expected seqMap[%s][%d] to be removed", u.String(), seq)
+		}
+	})
+
+	// test peekFirst
+	t.Run("peekFirst", func(t *testing.T) {
+		seq := 2
+		s.putElem(u, seq, time.Now())
+
+		elem := s.peekFirst()
+
+		// 检查 peekFirst 是否返回链表的第一个元素
+		if elem.seq != seq {
+			t.Errorf("Expected peekFirst to return element with seq %d, got %d", seq, elem.seq)
+		}
+	})
+}
+
+func TestSeqMap2(t *testing.T) {
+	u := uuid.New()
+	s := newSeqMap(u)
+	for i := 0; i < 100; i++ {
+		s.putElem(u, i, time.Now())
+	}
+	for i := 0; i < 100; i++ {
+		e, ok := s.getElem(u, i)
+		AssertTrue(t, ok && e.seq == i)
+	}
+	for i := 0; i < 20; i++ {
+		first := s.peekFirst()
+		AssertTrue(t, first.seq == i)
+		s.removeElem(first)
+	}
+}


### PR DESCRIPTION
I believe that developers should have a way to know when a data packet is lost or does not return within a specified time.

you can set MaxRtt and OnTimeout func

Ontime func while be call when a request was not answered within a specified time

 you only need add:
``` go
  pinger.MaxRtt = time.Second * 3

  pinger.OnTimeOut = func(packet *probing.Packet) {
    fmt.Println("timeout", packet.Addr, packet.Rtt, packet.TTL)
  }
```

It has good compatibility, as if MaxRtt is not set, it will have the same behavior as before.

However, there are still some issues remaining.
- The timing is not precise; for example, if a maximum round-trip time (maxrtt) of 100ms is set, but the request time exceeds 101ms, it is possible that the OnRecv function will still be used.
- If a request is received after the timeout, the OnDuplicateRecv function will be called.

But I believe that this is acceptable.