### PR TITLE
Return ctx.Err() from RunWithContext() and Run()

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -491,6 +491,7 @@ func (p *Pinger) run(ctx context.Context, conn packetConn) error {
 		select {
 		case <-ctx.Done():
 			p.Stop()
+			return ctx.Err()
 		case <-p.done:
 		}
 		return nil

--- a/ping_test.go
+++ b/ping_test.go
@@ -784,7 +784,7 @@ func TestRunWithTimeoutContext(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	err = pinger.run(ctx, conn)
-	AssertTrue(t, err == nil)
+	AssertTrue(t, errors.Is(err, context.DeadlineExceeded))
 	elapsedTime := time.Since(start)
 	AssertTrue(t, elapsedTime < 10*time.Second)
 


### PR DESCRIPTION
`RunWithContext()` takes in a context and stops the pinger when the context is done, however it is difficult to capture the reason the context is closed.
It would be useful to do something like:

```
if err := pinger.RunWithContext(ctx); err != nil {
    if !errors.Is(err, context.Canceled) {
        // do something interesting only when context was not cancelled/closed
    }
}
```

This is currently not possible and we have to do something like this outside of `pinger.RunWithContext()` to achieve something similar:

```
        select {
	case <-ctx.Done():
		return
	default:
		// do something interesting only when context was not cancelled/closed/whatever
	}
```