### PR TITLE
Fix packet loss stat zero division

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -590,7 +590,12 @@ func (p *Pinger) Statistics() *Statistics {
 	p.statsMu.RLock()
 	defer p.statsMu.RUnlock()
 	sent := p.PacketsSent
-	loss := float64(sent-p.PacketsRecv) / float64(sent) * 100
+
+	var loss float64
+	if sent > 0 {
+		loss = float64(sent-p.PacketsRecv) / float64(sent) * 100
+	}
+
 	s := Statistics{
 		PacketsSent:           sent,
 		PacketsRecv:           p.PacketsRecv,

--- a/ping_test.go
+++ b/ping_test.go
@@ -477,6 +477,22 @@ func TestStatisticsLossy(t *testing.T) {
 	}
 }
 
+func TestStatisticsZeroDivision(t *testing.T) {
+	p := New("localhost")
+	err := p.Resolve()
+	AssertNoError(t, err)
+	AssertEqualStrings(t, "localhost", p.Addr())
+
+	p.PacketsSent = 0
+	stats := p.Statistics()
+
+	// If packets were not sent (due to send errors), ensure that
+	// PacketLoss is 0 instead of NaN due to zero division
+	if stats.PacketLoss != 0 {
+		t.Errorf("Expected %v, got %v", 0, stats.PacketLoss)
+	}
+}
+
 // Test helpers
 func makeTestPinger() *Pinger {
 	pinger := New("127.0.0.1")


### PR DESCRIPTION
If `PacketsSent` is 0 we end up doing zero division when calculating packet loss in `pinger.Statistics()` which ends up reporting as `NaN`. This can be problematic if one were to take the `pinger.Statistics` struct and marshal it into json, which will end up failing altogether due to having a value of `NaN`. Ref: https://github.com/golang/go/issues/3480

Running the test I added in this branch without any other code change highlights this problem:

```
$ go test -v ./... -run ^TestStatisticsZeroDivision$
?   	github.com/prometheus-community/pro-bing/cmd/ping	[no test files]
=== RUN   TestStatisticsZeroDivision
    ping_test.go:492: Expected 0, got NaN
--- FAIL: TestStatisticsZeroDivision (0.00s)
FAIL
FAIL	github.com/prometheus-community/pro-bing	0.512s
FAIL
```