### PR TITLE
Add resolve timeout

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -360,7 +360,7 @@ func (p *Pinger) Resolve() error {
 			return err
 		}
 		if len(ips) == 0 {
-			return fmt.Errorf("lookup %s failed: ip not found", p.addr)
+			return fmt.Errorf("lookup %s failed: no addresses found", p.addr)
 		}
 		ipaddr = &net.IPAddr{IP: ips[0]}
 		for _, ip := range ips {

--- a/ping_test.go
+++ b/ping_test.go
@@ -833,3 +833,21 @@ func TestRunWithBackgroundContext(t *testing.T) {
 	}
 	AssertTrue(t, stats.PacketsRecv == 10)
 }
+
+func TestSetResolveTimeout(t *testing.T) {
+	p := New("www.google.com")
+	p.Count = 3
+	p.Timeout = 5 * time.Second
+	p.ResolveTimeout = 2 * time.Second
+	err := p.Resolve()
+	AssertNoError(t, err)
+
+	err = p.SetAddr("www.google.com ")
+	AssertError(t, err, "")
+
+	err = p.SetAddr("127.0.0.1 ")
+	AssertError(t, err, "")
+
+	err = p.SetAddr("127.0.0.1")
+	AssertNoError(t, err)
+}


### PR DESCRIPTION
This is an example code where the program will block for approximately 30 seconds. This behavior can be counterintuitive in some cases because the Timeout is set but fails to stop the ongoing resolving process. However, when using the Ping command, the ongoing resolution process is terminated based on the specified timeout (-t).
```go
package main

import (
	"fmt"
	ping "github.com/prometheus-community/pro-bing"
	"time"
)

func main() {
	start := time.Now()
	defer func() {
		fmt.Println(time.Since(start))
		// 30.003322236s
		// panic: lookup 8.8.8.8 : no such host
	}()
	pinger, err := ping.NewPinger("8.8.8.8 ")
	if err != nil {
		panic(err)
	}
	pinger.Count = 3
	pinger.Timeout = 1 * time.Second
	pinger.RecordRtts = false
	err = pinger.Run() // Blocks until finished.
	if err != nil {
		panic(err)
	}
}
```
To address this issue, I have added the ResolveTimeout, which handles situations where the resolve time exceeds a certain threshold. 
While expanding the Timeout to influence the resolve time might be a potential solution, it could have backward compatibility implications?
Based on this, I have opted to submit the ResolveTimeout version.