### PR TITLE
Fix broadcast address and enable unprivileged broadcast ping

### DIFF
--- a/packetconn.go
+++ b/packetconn.go
@@ -20,6 +20,7 @@ type packetConn interface {
 	SetTTL(ttl int)
 	SetMark(m uint) error
 	SetDoNotFragment() error
+	SetBroadcastFlag() error
 }
 
 type icmpConn struct {

--- a/ping_test.go
+++ b/ping_test.go
@@ -16,6 +16,10 @@ import (
 	"golang.org/x/net/ipv4"
 )
 
+var testAddr net.Addr = &net.IPAddr{
+	IP: net.IPv4(127, 0, 0, 1),
+}
+
 func TestProcessPacket(t *testing.T) {
 	pinger := makeTestPinger()
 	shouldBe1 := 0
@@ -49,11 +53,7 @@ func TestProcessPacket(t *testing.T) {
 
 	msgBytes, _ := msg.Marshal(nil)
 
-	pkt := packet{
-		nbytes: len(msgBytes),
-		bytes:  msgBytes,
-		ttl:    24,
-	}
+	pkt := makeTestPacket(msgBytes)
 
 	err = pinger.processPacket(&pkt)
 	AssertNoError(t, err)
@@ -91,11 +91,7 @@ func TestProcessPacket_IgnoreNonEchoReplies(t *testing.T) {
 
 	msgBytes, _ := msg.Marshal(nil)
 
-	pkt := packet{
-		nbytes: len(msgBytes),
-		bytes:  msgBytes,
-		ttl:    24,
-	}
+	pkt := makeTestPacket(msgBytes)
 
 	err = pinger.processPacket(&pkt)
 	AssertNoError(t, err)
@@ -134,11 +130,7 @@ func TestProcessPacket_IDMismatch(t *testing.T) {
 
 	msgBytes, _ := msg.Marshal(nil)
 
-	pkt := packet{
-		nbytes: len(msgBytes),
-		bytes:  msgBytes,
-		ttl:    24,
-	}
+	pkt := makeTestPacket(msgBytes)
 
 	err = pinger.processPacket(&pkt)
 	AssertNoError(t, err)
@@ -176,11 +168,7 @@ func TestProcessPacket_TrackerMismatch(t *testing.T) {
 
 	msgBytes, _ := msg.Marshal(nil)
 
-	pkt := packet{
-		nbytes: len(msgBytes),
-		bytes:  msgBytes,
-		ttl:    24,
-	}
+	pkt := makeTestPacket(msgBytes)
 
 	err = pinger.processPacket(&pkt)
 	AssertNoError(t, err)
@@ -214,11 +202,7 @@ func TestProcessPacket_LargePacket(t *testing.T) {
 
 	msgBytes, _ := msg.Marshal(nil)
 
-	pkt := packet{
-		nbytes: len(msgBytes),
-		bytes:  msgBytes,
-		ttl:    24,
-	}
+	pkt := makeTestPacket(msgBytes)
 
 	err = pinger.processPacket(&pkt)
 	AssertNoError(t, err)
@@ -242,11 +226,7 @@ func TestProcessPacket_PacketTooSmall(t *testing.T) {
 
 	msgBytes, _ := msg.Marshal(nil)
 
-	pkt := packet{
-		nbytes: len(msgBytes),
-		bytes:  msgBytes,
-		ttl:    24,
-	}
+	pkt := makeTestPacket(msgBytes)
 
 	err := pinger.processPacket(&pkt)
 	AssertError(t, err, "")
@@ -506,6 +486,16 @@ func makeTestPinger() *Pinger {
 	return pinger
 }
 
+// makeTestPacket emulates a packet with the message msg which come from testAddr
+func makeTestPacket(msg []byte) packet {
+	return packet{
+		bytes:  msg,
+		nbytes: len(msg),
+		ttl:    24,
+		addr:   testAddr,
+	}
+}
+
 func AssertNoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {
@@ -583,11 +573,7 @@ func BenchmarkProcessPacket(b *testing.B) {
 
 	msgBytes, _ := msg.Marshal(nil)
 
-	pkt := packet{
-		nbytes: len(msgBytes),
-		bytes:  msgBytes,
-		ttl:    24,
-	}
+	pkt := makeTestPacket(msgBytes)
 
 	for k := 0; k < b.N; k++ {
 		pinger.processPacket(&pkt)
@@ -635,11 +621,7 @@ func TestProcessPacket_IgnoresDuplicateSequence(t *testing.T) {
 
 	msgBytes, _ := msg.Marshal(nil)
 
-	pkt := packet{
-		nbytes: len(msgBytes),
-		bytes:  msgBytes,
-		ttl:    24,
-	}
+	pkt := makeTestPacket(msgBytes)
 
 	err = pinger.processPacket(&pkt)
 	AssertNoError(t, err)
@@ -663,7 +645,7 @@ func (c testPacketConn) SetMark(m uint) error              { return nil }
 func (c testPacketConn) SetDoNotFragment() error           { return nil }
 
 func (c testPacketConn) ReadFrom(b []byte) (n int, ttl int, src net.Addr, err error) {
-	return 0, 0, nil, nil
+	return 0, 0, testAddr, nil
 }
 
 func (c testPacketConn) WriteTo(b []byte, dst net.Addr) (int, error) {
@@ -704,7 +686,7 @@ type testPacketConnBadRead struct {
 }
 
 func (c testPacketConnBadRead) ReadFrom(b []byte) (n int, ttl int, src net.Addr, err error) {
-	return 0, 0, nil, errors.New("bad read")
+	return 0, 0, testAddr, errors.New("bad read")
 }
 
 func TestRunBadRead(t *testing.T) {
@@ -750,7 +732,7 @@ func (c *testPacketConnOK) ReadFrom(b []byte) (n int, ttl int, src net.Addr, err
 	c.m.Lock()
 	defer c.m.Unlock()
 	if atomic.LoadInt32(&c.writeDone) == 0 {
-		return 0, 0, nil, nil
+		return 0, 0, testAddr, nil
 	}
 	msg, err := icmp.ParseMessage(ipv4.ICMPTypeEcho.Protocol(), c.buf)
 	if err != nil {
@@ -762,7 +744,7 @@ func (c *testPacketConnOK) ReadFrom(b []byte) (n int, ttl int, src net.Addr, err
 		return 0, 0, nil, err
 	}
 	time.Sleep(10 * time.Millisecond)
-	return copy(b, buf), 64, c.dst, nil
+	return copy(b, buf), 64, testAddr, nil
 }
 
 func TestRunOK(t *testing.T) {

--- a/ping_test.go
+++ b/ping_test.go
@@ -643,6 +643,7 @@ func (c testPacketConn) SetReadDeadline(t time.Time) error { return nil }
 func (c testPacketConn) SetTTL(t int)                      {}
 func (c testPacketConn) SetMark(m uint) error              { return nil }
 func (c testPacketConn) SetDoNotFragment() error           { return nil }
+func (c testPacketConn) SetBroadcastFlag() error           { return nil }
 
 func (c testPacketConn) ReadFrom(b []byte) (n int, ttl int, src net.Addr, err error) {
 	return 0, 0, testAddr, nil

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -101,6 +101,42 @@ func (c *icmpV6Conn) SetDoNotFragment() error {
 	)
 }
 
+func (c *icmpConn) SetBroadcastFlag() error {
+	fd, err := getFD(c.c)
+	if err != nil {
+		return err
+	}
+
+	return os.NewSyscallError(
+		"setsockopt",
+		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_BROADCAST, 1),
+	)
+}
+
+func (c *icmpv4Conn) SetBroadcastFlag() error {
+	fd, err := getFD(c.icmpConn.c)
+	if err != nil {
+		return err
+	}
+
+	return os.NewSyscallError(
+		"setsockopt",
+		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_BROADCAST, 1),
+	)
+}
+
+func (c *icmpV6Conn) SetBroadcastFlag() error {
+	fd, err := getFD(c.icmpConn.c)
+	if err != nil {
+		return err
+	}
+
+	return os.NewSyscallError(
+		"setsockopt",
+		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_BROADCAST, 1),
+	)
+}
+
 // getFD gets the system file descriptor for an icmp.PacketConn
 func getFD(c *icmp.PacketConn) (uintptr, error) {
 	v := reflect.ValueOf(c).Elem().FieldByName("c").Elem()

--- a/utils_other.go
+++ b/utils_other.go
@@ -45,3 +45,16 @@ func (c *icmpv4Conn) SetDoNotFragment() error {
 func (c *icmpV6Conn) SetDoNotFragment() error {
 	return ErrDFNotSupported
 }
+
+// No need for SetBroadcastFlag in non-linux OSes
+func (c *icmpConn) SetBroadcastFlag() error {
+	return nil
+}
+
+func (c *icmpv4Conn) SetBroadcastFlag() error {
+	return nil
+}
+
+func (c *icmpV6Conn) SetBroadcastFlag() error {
+	return nil
+}

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -56,3 +56,16 @@ func (c *icmpv4Conn) SetDoNotFragment() error {
 func (c *icmpV6Conn) SetDoNotFragment() error {
 	return ErrDFNotSupported
 }
+
+// No need for SetBroadcastFlag in non-linux OSes
+func (c *icmpConn) SetBroadcastFlag() error {
+	return nil
+}
+
+func (c *icmpv4Conn) SetBroadcastFlag() error {
+	return nil
+}
+
+func (c *icmpV6Conn) SetBroadcastFlag() error {
+	return nil
+}


### PR DESCRIPTION
In first commit #15 is fixed.
In second commit "unprivileged" broadcast ping feature is added. 

Tests:
- ✅ Linux (unprivileged and privileged)
- ✅ Mac (unprivileged and privileged)
- Windows: Native windows `ping` command doesn't support broadcast pinging I didn't work on that.

Second commit may be useful for prometheus community, some may use it like: "create alarm when ping reply < 10 in 1 min" or so, but they may want to use non-root security principles.

EDIT: I have nearly zero knowledge on ipv6 but AFAIK it does not use broadcast addresses.

<details><summary>Screenshots</summary>

Linux: 
<p align="center">
  <img width="500" alt="linux-screenshot" src="https://github.com/prometheus-community/pro-bing/assets/58051033/bd9bc938-97dd-44e6-a659-4ac7311e38d4">
</p>

Mac:
<p align="center">
  <img width="500" alt="mac-screenshot" src="https://github.com/prometheus-community/pro-bing/assets/58051033/ef610182-5eec-4084-a177-b4a24b9a369c">
</p>
</details>