### PR TITLE
Add the `InterfaceName` option to `Pinger`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ jobs:
       use_gomod_cache:
         type: boolean
         default: true
-    docker:
-      - image: cimg/go:<< parameters.go_version >>
+    machine:
+      image: ubuntu-2204:2024.05.1
     steps:
       - checkout
       - when:

--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -13,7 +13,7 @@ import (
 var usage = `
 Usage:
 
-    ping [-c count] [-i interval] [-t timeout] [--privileged] host
+    ping [-c count] [-i interval] [-t timeout] [-I interface] [--privileged] host
 
 Examples:
 
@@ -29,6 +29,9 @@ Examples:
     # ping google for 10 seconds
     ping -t 10s www.google.com
 
+    # ping google specified interface
+    ping -I eth1 www.goole.com
+
     # Send a privileged raw ICMP ping
     sudo ping --privileged www.google.com
 
@@ -42,6 +45,7 @@ func main() {
 	count := flag.Int("c", -1, "")
 	size := flag.Int("s", 24, "")
 	ttl := flag.Int("l", 64, "TTL")
+	iface := flag.String("I", "", "interface name")
 	privileged := flag.Bool("privileged", false, "")
 	flag.Usage = func() {
 		fmt.Print(usage)
@@ -90,6 +94,7 @@ func main() {
 	pinger.Interval = *interval
 	pinger.Timeout = *timeout
 	pinger.TTL = *ttl
+	pinger.InterfaceDevice = *iface
 	pinger.SetPrivileged(*privileged)
 
 	fmt.Printf("PING %s (%s):\n", pinger.Addr(), pinger.IPAddr())

--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -94,7 +94,7 @@ func main() {
 	pinger.Interval = *interval
 	pinger.Timeout = *timeout
 	pinger.TTL = *ttl
-	pinger.InterfaceDevice = *iface
+	pinger.InterfaceName = *iface
 	pinger.SetPrivileged(*privileged)
 
 	fmt.Printf("PING %s (%s):\n", pinger.Addr(), pinger.IPAddr())

--- a/packetconn.go
+++ b/packetconn.go
@@ -21,11 +21,13 @@ type packetConn interface {
 	SetMark(m uint) error
 	SetDoNotFragment() error
 	SetBroadcastFlag() error
+	SetIfIndex(ifIndex int)
 }
 
 type icmpConn struct {
-	c   *icmp.PacketConn
-	ttl int
+	c       *icmp.PacketConn
+	ttl     int
+	ifIndex int
 }
 
 func (c *icmpConn) Close() error {
@@ -36,23 +38,12 @@ func (c *icmpConn) SetTTL(ttl int) {
 	c.ttl = ttl
 }
 
-func (c *icmpConn) SetReadDeadline(t time.Time) error {
-	return c.c.SetReadDeadline(t)
+func (c *icmpConn) SetIfIndex(ifIndex int) {
+	c.ifIndex = ifIndex
 }
 
-func (c *icmpConn) WriteTo(b []byte, dst net.Addr) (int, error) {
-	if c.c.IPv6PacketConn() != nil {
-		if err := c.c.IPv6PacketConn().SetHopLimit(c.ttl); err != nil {
-			return 0, err
-		}
-	}
-	if c.c.IPv4PacketConn() != nil {
-		if err := c.c.IPv4PacketConn().SetTTL(c.ttl); err != nil {
-			return 0, err
-		}
-	}
-
-	return c.c.WriteTo(b, dst)
+func (c *icmpConn) SetReadDeadline(t time.Time) error {
+	return c.c.SetReadDeadline(t)
 }
 
 type icmpv4Conn struct {
@@ -74,6 +65,22 @@ func (c *icmpv4Conn) ReadFrom(b []byte) (int, int, net.Addr, error) {
 		ttl = cm.TTL
 	}
 	return n, ttl, src, err
+}
+
+func (c *icmpv4Conn) WriteTo(b []byte, dst net.Addr) (int, error) {
+	if err := c.c.IPv4PacketConn().SetTTL(c.ttl); err != nil {
+		return 0, err
+	}
+	var cm *ipv4.ControlMessage
+	if 1 <= c.ifIndex {
+		// c.ifIndex == 0 if not set interface
+		if err := c.c.IPv4PacketConn().SetControlMessage(ipv4.FlagInterface, true); err != nil {
+			return 0, err
+		}
+		cm = &ipv4.ControlMessage{IfIndex: c.ifIndex}
+	}
+
+	return c.c.IPv4PacketConn().WriteTo(b, cm, dst)
 }
 
 func (c icmpv4Conn) ICMPRequestType() icmp.Type {
@@ -99,6 +106,22 @@ func (c *icmpV6Conn) ReadFrom(b []byte) (int, int, net.Addr, error) {
 		ttl = cm.HopLimit
 	}
 	return n, ttl, src, err
+}
+
+func (c *icmpV6Conn) WriteTo(b []byte, dst net.Addr) (int, error) {
+	if err := c.c.IPv6PacketConn().SetHopLimit(c.ttl); err != nil {
+		return 0, err
+	}
+	var cm *ipv6.ControlMessage
+	if 1 <= c.ifIndex {
+		// c.ifIndex == 0 if not set interface
+		if err := c.c.IPv6PacketConn().SetControlMessage(ipv6.FlagInterface, true); err != nil {
+			return 0, err
+		}
+		cm = &ipv6.ControlMessage{IfIndex: c.ifIndex}
+	}
+
+	return c.c.IPv6PacketConn().WriteTo(b, cm, dst)
 }
 
 func (c icmpV6Conn) ICMPRequestType() icmp.Type {

--- a/ping.go
+++ b/ping.go
@@ -208,7 +208,7 @@ type Pinger struct {
 	Source string
 
 	// Interface used to send/recv ICMP messages
-	InterfaceDevice string
+	InterfaceName string
 
 	// Channel and mutex used to communicate when the Pinger should stop between goroutines.
 	done chan interface{}
@@ -528,8 +528,8 @@ func (p *Pinger) RunWithContext(ctx context.Context) error {
 	}
 
 	conn.SetTTL(p.TTL)
-	if p.InterfaceDevice != "" {
-		iface, err := net.InterfaceByName(p.InterfaceDevice)
+	if p.InterfaceName != "" {
+		iface, err := net.InterfaceByName(p.InterfaceName)
 		if err != nil {
 			return err
 		}

--- a/ping.go
+++ b/ping.go
@@ -207,6 +207,9 @@ type Pinger struct {
 	// Source is the source IP address
 	Source string
 
+	// Interface used to send/recv ICMP messages
+	InterfaceDevice string
+
 	// Channel and mutex used to communicate when the Pinger should stop between goroutines.
 	done chan interface{}
 	lock sync.Mutex
@@ -525,6 +528,13 @@ func (p *Pinger) RunWithContext(ctx context.Context) error {
 	}
 
 	conn.SetTTL(p.TTL)
+	if p.InterfaceDevice != "" {
+		iface, err := net.InterfaceByName(p.InterfaceDevice)
+		if err != nil {
+			return err
+		}
+		conn.SetIfIndex(iface.Index)
+	}
 	return p.run(ctx, conn)
 }
 

--- a/ping_test.go
+++ b/ping_test.go
@@ -480,7 +480,7 @@ func TestSetInterfaceName(t *testing.T) {
 	pinger.Timeout = time.Second
 
 	// Set loopback interface
-	pinger.InterfaceDevice = "lo"
+	pinger.InterfaceName = "lo"
 	err := pinger.Run()
 	if runtime.GOOS == "linux" {
 		AssertNoError(t, err)
@@ -489,7 +489,7 @@ func TestSetInterfaceName(t *testing.T) {
 	}
 
 	// Set fake interface
-	pinger.InterfaceDevice = "L()0pB@cK"
+	pinger.InterfaceName = "L()0pB@cK"
 	err = pinger.Run()
 	AssertError(t, err, "device not found")
 }


### PR DESCRIPTION
This is a rebase of #32 to match the current HEAD on main.

This allows using `pro-bing` to use VRFs interfaces and IPv6 link-local addresses.