### PR TITLE
filter icmp id with sock_filter, to optimize rawsocket preformance

### DIFF
--- a/packetconn.go
+++ b/packetconn.go
@@ -23,6 +23,7 @@ type packetConn interface {
 	SetBroadcastFlag() error
 	SetIfIndex(ifIndex int)
 	SetTrafficClass(uint8) error
+	InstallICMPIDFilter(id int) error
 }
 
 type icmpConn struct {

--- a/ping.go
+++ b/ping.go
@@ -88,8 +88,9 @@ var (
 	ipv4Proto = map[string]string{"icmp": "ip4:icmp", "udp": "udp4"}
 	ipv6Proto = map[string]string{"icmp": "ip6:ipv6-icmp", "udp": "udp6"}
 
-	ErrMarkNotSupported = errors.New("setting SO_MARK socket option is not supported on this platform")
-	ErrDFNotSupported   = errors.New("setting do-not-fragment bit is not supported on this platform")
+	ErrMarkNotSupported     = errors.New("setting SO_MARK socket option is not supported on this platform")
+	ErrDFNotSupported       = errors.New("setting do-not-fragment bit is not supported on this platform")
+	ErrSockFilterNotSupport = errors.New("setting SO_ATTACH_FILTER socket option is not supported on this platform")
 )
 
 // New returns a new Pinger struct pointer.
@@ -979,6 +980,11 @@ func (p *Pinger) listen() (packetConn, error) {
 		p.Stop()
 		return nil, err
 	}
+
+	if p.Privileged() {
+		conn.InstallICMPIDFilter(p.id)
+	}
+
 	return conn, nil
 }
 

--- a/ping_test.go
+++ b/ping_test.go
@@ -677,6 +677,7 @@ func (c testPacketConn) SetTTL(t int)                      {}
 func (c testPacketConn) SetMark(m uint) error              { return nil }
 func (c testPacketConn) SetDoNotFragment() error           { return nil }
 func (c testPacketConn) SetBroadcastFlag() error           { return nil }
+func (c testPacketConn) InstallICMPIDFilter(id int) error  { return nil }
 func (c testPacketConn) SetIfIndex(ifIndex int)            {}
 func (c testPacketConn) SetTrafficClass(uint8) error       { return nil }
 

--- a/utils_other.go
+++ b/utils_other.go
@@ -58,3 +58,11 @@ func (c *icmpv4Conn) SetBroadcastFlag() error {
 func (c *icmpV6Conn) SetBroadcastFlag() error {
 	return nil
 }
+
+func (c *icmpv4Conn) InstallICMPIDFilter(id int) error {
+	return ErrSockFilterNotSupport
+}
+
+func (c *icmpV6Conn) InstallICMPIDFilter(id int) error {
+	return ErrSockFilterNotSupport
+}

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -86,3 +86,11 @@ func (c *icmpv4Conn) SetBroadcastFlag() error {
 func (c *icmpV6Conn) SetBroadcastFlag() error {
 	return nil
 }
+
+func (c *icmpv4Conn) InstallICMPIDFilter(id int) error {
+	return ErrSockFilterNotSupport
+}
+
+func (c *icmpV6Conn) InstallICMPIDFilter(id int) error {
+	return ErrSockFilterNotSupport
+}


### PR DESCRIPTION
rawsocket will receive all packets matching the target protocol, including replies to another ping on this host.
with sock_filter we can filter icmp reply packets, only accepting icmp replies that match the id in the sent packet.