### PR TITLE
Add ICMP time exceeded support

### DIFF
--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -84,6 +84,10 @@ func main() {
 		fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v ttl=%v (DUP!)\n",
 			pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt, pkt.TTL)
 	}
+	pinger.OnTimeExceeded = func(pkt *probing.Packet) {
+		fmt.Printf("From %s: icmp_seq=%d time=%v Time to live exceeded\n",
+			pkt.IPAddr, pkt.Seq, pkt.Rtt)
+	}
 	pinger.OnFinish = func(stats *probing.Statistics) {
 		fmt.Printf("\n--- %s ping statistics ---\n", stats.Addr)
 		fmt.Printf("%d packets transmitted, %d packets received, %d duplicates, %v%% packet loss\n",

--- a/ping.go
+++ b/ping.go
@@ -82,6 +82,21 @@ const (
 	networkIP   = "ip"
 	networkIPv4 = "ip4"
 	networkIPv6 = "ip6"
+
+	// Time Exceeded message structure sizes (RFC 792 for IPv4, RFC 4443 for IPv6)
+	// ICMP Time Exceeded header (8) + IP header (20/40) + ICMP Echo header (8)
+	timeExceededMinSizeIPv4 = 36 // 8 + 20 + 8
+	timeExceededMinSizeIPv6 = 56 // 8 + 40 + 8
+
+	// ICMP ID offset in embedded ICMP Echo Request within Time Exceeded
+	// ICMP Time Exceeded header (8) + IP header (20/40) + ICMP Echo type/code/checksum (4)
+	timeExceededIDOffsetIPv4 = 32 // 8 + 20 + 4
+	timeExceededIDOffsetIPv6 = 52 // 8 + 40 + 4
+
+	// Sequence number offset in embedded ICMP Echo Request within Time Exceeded
+	// ICMP Time Exceeded header (8) + IP header (20/40) + ICMP Echo type/code/checksum (4) + ICMP Echo ID (2)
+	timeExceededSeqOffsetIPv4 = 34 // 8 + 20 + 6
+	timeExceededSeqOffsetIPv6 = 54 // 8 + 40 + 6
 )
 
 var (
@@ -96,8 +111,8 @@ var (
 func New(addr string) *Pinger {
 	r := rand.New(rand.NewSource(getSeed()))
 	firstUUID := uuid.New()
-	var firstSequence = map[uuid.UUID]map[int]struct{}{}
-	firstSequence[firstUUID] = make(map[int]struct{})
+	var firstSequence = map[uuid.UUID]map[int]time.Time{}
+	firstSequence[firstUUID] = make(map[int]time.Time)
 	return &Pinger{
 		Count:      -1,
 		Interval:   time.Second,
@@ -193,6 +208,9 @@ type Pinger struct {
 	// OnDuplicateRecv is called when a packet is received that has already been received.
 	OnDuplicateRecv func(*Packet)
 
+	// OnTimeExceeded is called when an ICMP Time Exceeded message is received.
+	OnTimeExceeded func(*Packet)
+
 	// OnSendError is called when an error occurs while Pinger attempts to send a packet
 	OnSendError func(*Packet, error)
 
@@ -231,7 +249,8 @@ type Pinger struct {
 	id       int
 	sequence int
 	// awaitingSequences are in-flight sequence numbers we keep track of to help remove duplicate receipts
-	awaitingSequences map[uuid.UUID]map[int]struct{}
+	// awaitingSequences also tracks sequence number send times
+	awaitingSequences map[uuid.UUID]map[int]time.Time
 	// network is one of "ip", "ip4", or "ip6".
 	network string
 	// protocol is "icmp" or "udp".
@@ -755,7 +774,20 @@ func (p *Pinger) recvICMP(
 		case <-p.done:
 			return nil
 		default:
-			bytes := make([]byte, p.getMessageLength()+offset)
+			// Calculate buffer size to accommodate both Echo Reply and Time Exceeded messages.
+			// Time Exceeded messages are larger, so use the maximum of the two sizes.
+			var minTimeExceededSize int
+			if p.ipv4 {
+				minTimeExceededSize = timeExceededMinSizeIPv4 + p.Size + offset
+			} else {
+				minTimeExceededSize = timeExceededMinSizeIPv6 + p.Size + offset
+			}
+
+			bufferSize := p.getMessageLength() + offset
+			if bufferSize < minTimeExceededSize {
+				bufferSize = minTimeExceededSize
+			}
+			bytes := make([]byte, bufferSize)
 			if err := conn.SetReadDeadline(time.Now().Add(delay)); err != nil {
 				return err
 			}
@@ -821,8 +853,83 @@ func (p *Pinger) processPacket(recv *packet) error {
 		return fmt.Errorf("error parsing icmp message: %w", err)
 	}
 
+	// Handle ICMP Time Exceeded messages
+	if m.Type == ipv4.ICMPTypeTimeExceeded || m.Type == ipv6.ICMPTypeTimeExceeded {
+		// Only process if callback is set
+		if p.OnTimeExceeded == nil {
+			return nil
+		}
+
+		// Extract the source IP from the Time Exceeded message
+		var realIP *net.IPAddr
+		switch v := recv.addr.(type) {
+		case *net.IPAddr:
+			realIP = v
+		case *net.UDPAddr:
+			realIP = &net.IPAddr{IP: v.IP}
+		default:
+			realIP = p.ipaddr
+		}
+
+		// Extract ICMP ID and sequence number from the ICMP Echo Request that is embedded within the Time Exceeded message
+		var minSize int
+		var idOffset int
+		var seqOffset int
+
+		if p.ipv4 {
+			minSize = timeExceededMinSizeIPv4
+			idOffset = timeExceededIDOffsetIPv4
+			seqOffset = timeExceededSeqOffsetIPv4
+		} else {
+			minSize = timeExceededMinSizeIPv6
+			idOffset = timeExceededIDOffsetIPv6
+			seqOffset = timeExceededSeqOffsetIPv6
+		}
+
+		// Verify packet is large enough to extract ICMP ID and sequence number
+		if recv.nbytes < minSize {
+			return nil
+		}
+
+		// Extract and verify ICMP ID matches this pinger's ID
+		id := int(recv.bytes[idOffset])<<8 | int(recv.bytes[idOffset+1])
+		if id != p.id {
+			return nil // Not our packet, ignore
+		}
+
+		// Extract sequence number
+		seq := int(recv.bytes[seqOffset])<<8 | int(recv.bytes[seqOffset+1])
+
+		// Look up send time by sequence number
+		currentUUID := p.getCurrentTrackerUUID()
+		sendTime, ok := p.awaitingSequences[currentUUID][seq]
+		if !ok {
+			return nil
+		}
+		delete(p.awaitingSequences[currentUUID], seq)
+
+		rtt := receivedAt.Sub(sendTime)
+
+		pkt := &Packet{
+			Nbytes: recv.nbytes,
+			IPAddr: realIP,
+			Addr:   realIP.String(),
+			TTL:    recv.ttl,
+			ID:     p.id,
+			Seq:    seq,
+			Rtt:    rtt,
+		}
+
+		// Update statistics with the Time Exceeded packet
+		p.updateStatistics(pkt)
+
+		p.OnTimeExceeded(pkt)
+
+		return nil
+	}
+
 	if m.Type != ipv4.ICMPTypeEchoReply && m.Type != ipv6.ICMPTypeEchoReply {
-		// Not an echo reply, ignore it
+		// Not an echo reply or time exceeded, ignore it
 		return nil
 	}
 
@@ -962,8 +1069,8 @@ func (p *Pinger) sendICMP(conn packetConn) error {
 			}
 			p.OnSend(outPkt)
 		}
-		// mark this sequence as in-flight
-		p.awaitingSequences[currentUUID][p.sequence] = struct{}{}
+		// mark this sequence as in-flight and record send time
+		p.awaitingSequences[currentUUID][p.sequence] = time.Now()
 		p.statsMu.Lock()
 		p.PacketsSent++
 		p.statsMu.Unlock()
@@ -971,7 +1078,7 @@ func (p *Pinger) sendICMP(conn packetConn) error {
 		if p.sequence > 65535 {
 			newUUID := uuid.New()
 			p.trackerUUIDs = append(p.trackerUUIDs, newUUID)
-			p.awaitingSequences[newUUID] = make(map[int]struct{})
+			p.awaitingSequences[newUUID] = make(map[int]time.Time)
 			p.sequence = 0
 		}
 		break

--- a/ping_test.go
+++ b/ping_test.go
@@ -44,7 +44,7 @@ func TestProcessPacket(t *testing.T) {
 		Seq:  pinger.sequence,
 		Data: data,
 	}
-	pinger.awaitingSequences[currentUUID][pinger.sequence] = struct{}{}
+	pinger.awaitingSequences[currentUUID][pinger.sequence] = time.Now()
 
 	msg := &icmp.Message{
 		Type: ipv4.ICMPTypeEchoReply,
@@ -231,6 +231,193 @@ func TestProcessPacket_PacketTooSmall(t *testing.T) {
 
 	err := pinger.processPacket(&pkt)
 	AssertError(t, err, "")
+}
+
+func TestProcessPacket_TimeExceeded(t *testing.T) {
+	pinger := makeTestPinger()
+	shouldBe1 := 0
+	var receivedPkt *Packet
+
+	// OnTimeExceeded callback should be called
+	pinger.OnTimeExceeded = func(pkt *Packet) {
+		shouldBe1++
+		receivedPkt = pkt
+	}
+
+	currentUUID := pinger.getCurrentTrackerUUID()
+	seq := 5
+
+	// Record send time for this sequence
+	pinger.awaitingSequences[currentUUID][seq] = time.Now().Add(-20 * time.Millisecond)
+
+	// Create a Time Exceeded message with embedded ICMP Echo Request
+	// Structure: TIME_EXCEEDED header (8 bytes) + IP header (20 bytes) + ICMP Echo (8+ bytes)
+	embeddedICMP := make([]byte, 36)
+	// ICMP TIME_EXCEEDED header (8 bytes) - all zeros is fine for test
+	// Embedded IP header (20 bytes) - skip for test
+	// Embedded ICMP Echo Request header (8 bytes)
+	embeddedICMP[28] = 8 // ICMP Type: Echo Request
+	embeddedICMP[29] = 0 // ICMP Code
+	// Checksum at 30-31 (skip)
+	// ID at 32-33 - must match pinger.id
+	embeddedICMP[32] = byte(pinger.id >> 8)
+	embeddedICMP[33] = byte(pinger.id)
+	// Sequence at 34-35
+	embeddedICMP[34] = byte(seq >> 8)
+	embeddedICMP[35] = byte(seq)
+
+	msg := &icmp.Message{
+		Type: ipv4.ICMPTypeTimeExceeded,
+		Code: 0,
+		Body: &icmp.TimeExceeded{
+			Data: embeddedICMP[8:], // Skip TIME_EXCEEDED header for Body
+		},
+	}
+
+	msgBytes, _ := msg.Marshal(nil)
+	pkt := makeTestPacket(msgBytes)
+
+	err := pinger.processPacket(&pkt)
+	AssertNoError(t, err)
+	AssertTrue(t, shouldBe1 == 1)
+	AssertTrue(t, receivedPkt != nil)
+	AssertTrue(t, receivedPkt.Seq == seq)
+	AssertTrue(t, receivedPkt.Rtt > 0)
+
+	// Verify send time was cleaned up
+	_, exists := pinger.awaitingSequences[currentUUID][seq]
+	AssertTrue(t, !exists)
+}
+
+func TestProcessPacket_TimeExceeded_NoCallback(t *testing.T) {
+	pinger := makeTestPinger()
+
+	// OnTimeExceeded is nil - should not panic
+	pinger.OnTimeExceeded = nil
+
+	currentUUID := pinger.getCurrentTrackerUUID()
+	seq := 5
+	pinger.awaitingSequences[currentUUID][seq] = time.Now()
+
+	embeddedICMP := make([]byte, 36)
+	embeddedICMP[28] = 8
+	embeddedICMP[34] = byte(seq >> 8)
+	embeddedICMP[35] = byte(seq)
+
+	msg := &icmp.Message{
+		Type: ipv4.ICMPTypeTimeExceeded,
+		Code: 0,
+		Body: &icmp.TimeExceeded{
+			Data: embeddedICMP[8:],
+		},
+	}
+
+	msgBytes, _ := msg.Marshal(nil)
+	pkt := makeTestPacket(msgBytes)
+
+	err := pinger.processPacket(&pkt)
+	AssertNoError(t, err)
+
+	// Send time should NOT be cleaned up when callback is nil
+	_, exists := pinger.awaitingSequences[currentUUID][seq]
+	AssertTrue(t, exists)
+}
+
+func TestProcessPacket_TimeExceeded_TruncatedPacket(t *testing.T) {
+	pinger := makeTestPinger()
+	shouldBe0 := 0
+
+	pinger.OnTimeExceeded = func(pkt *Packet) {
+		shouldBe0++
+	}
+
+	// Create truncated packet (less than 36 bytes)
+	embeddedICMP := make([]byte, 30) // Too short
+
+	msg := &icmp.Message{
+		Type: ipv4.ICMPTypeTimeExceeded,
+		Code: 0,
+		Body: &icmp.TimeExceeded{
+			Data: embeddedICMP[8:],
+		},
+	}
+
+	msgBytes, _ := msg.Marshal(nil)
+	pkt := makeTestPacket(msgBytes)
+	pkt.nbytes = 30 // Simulate truncated packet
+
+	err := pinger.processPacket(&pkt)
+	AssertNoError(t, err)
+	AssertTrue(t, shouldBe0 == 0) // Callback should not be called
+}
+
+func TestProcessPacket_TimeExceeded_NoSendTime(t *testing.T) {
+	pinger := makeTestPinger()
+	shouldBe0 := 0
+
+	pinger.OnTimeExceeded = func(pkt *Packet) {
+		shouldBe0++
+	}
+
+	seq := 99 // Sequence with no recorded send time
+
+	embeddedICMP := make([]byte, 36)
+	embeddedICMP[28] = 8
+	embeddedICMP[34] = byte(seq >> 8)
+	embeddedICMP[35] = byte(seq)
+
+	msg := &icmp.Message{
+		Type: ipv4.ICMPTypeTimeExceeded,
+		Code: 0,
+		Body: &icmp.TimeExceeded{
+			Data: embeddedICMP[8:],
+		},
+	}
+
+	msgBytes, _ := msg.Marshal(nil)
+	pkt := makeTestPacket(msgBytes)
+
+	err := pinger.processPacket(&pkt)
+	AssertNoError(t, err)
+	AssertTrue(t, shouldBe0 == 0) // Callback should not be called without send time
+}
+
+func TestProcessPacket_TimeExceeded_IncrementsPacketsRecv(t *testing.T) {
+	pinger := makeTestPinger()
+
+	pinger.OnTimeExceeded = func(pkt *Packet) {}
+
+	currentUUID := pinger.getCurrentTrackerUUID()
+	seq := 5
+	pinger.awaitingSequences[currentUUID][seq] = time.Now()
+
+	initialRecv := pinger.PacketsRecv
+
+	embeddedICMP := make([]byte, 36)
+	embeddedICMP[28] = 8 // ICMP Type: Echo Request
+	// ID at 32-33 - must match pinger.id
+	embeddedICMP[32] = byte(pinger.id >> 8)
+	embeddedICMP[33] = byte(pinger.id)
+	// Sequence at 34-35
+	embeddedICMP[34] = byte(seq >> 8)
+	embeddedICMP[35] = byte(seq)
+
+	msg := &icmp.Message{
+		Type: ipv4.ICMPTypeTimeExceeded,
+		Code: 0,
+		Body: &icmp.TimeExceeded{
+			Data: embeddedICMP[8:],
+		},
+	}
+
+	msgBytes, _ := msg.Marshal(nil)
+	pkt := makeTestPacket(msgBytes)
+
+	err := pinger.processPacket(&pkt)
+	AssertNoError(t, err)
+
+	// Verify PacketsRecv was incremented for early exit support
+	AssertTrue(t, pinger.PacketsRecv == initialRecv+1)
 }
 
 func TestNewPingerValid(t *testing.T) {
@@ -660,7 +847,7 @@ func TestProcessPacket_IgnoresDuplicateSequence(t *testing.T) {
 		Data: data,
 	}
 	// register the sequence as sent
-	pinger.awaitingSequences[currentUUID][0] = struct{}{}
+	pinger.awaitingSequences[currentUUID][0] = time.Now()
 
 	msg := &icmp.Message{
 		Type: ipv4.ICMPTypeEchoReply,

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -141,16 +141,29 @@ func (c *icmpV6Conn) SetBroadcastFlag() error {
 }
 
 // InstallICMPIDFilter attaches a BPF program to the connection to filter ICMP packets id.
+// Also accepts Time Exceeded messages.
 func (c *icmpv4Conn) InstallICMPIDFilter(id int) error {
 	filter, err := bpf.Assemble([]bpf.Instruction{
-		bpf.LoadMemShift{Off: 0},          // Skip IP header
-		bpf.LoadIndirect{Off: 0, Size: 1}, // Load ICMP type
-		bpf.JumpIf{Cond: bpf.JumpEqual, Val: uint32(ipv4.ICMPTypeEchoReply), SkipTrue: 1, SkipFalse: 0}, // Check if ICMP Echo Reply
-		bpf.RetConstant{Val: 0},           // Reject if false
-		bpf.LoadIndirect{Off: 4, Size: 2}, // Load ICMP echo ident
-		bpf.JumpIf{Cond: bpf.JumpEqual, Val: uint32(id), SkipTrue: 0, SkipFalse: 1}, // Check if it matches our identifier
-		bpf.RetConstant{Val: ^uint32(0)},                                            // Accept if true
-		bpf.RetConstant{Val: 0},                                                     // Reject if false
+		// Skip IP header (variable length)
+		bpf.LoadMemShift{Off: 0},
+		// Load ICMP type
+		bpf.LoadIndirect{Off: 0, Size: 1},
+
+		// BRANCH 1: Is this packet type Time Exceeded?
+		// If yes, ACCEPT immediately. We will filter by ID in Go (User Space).
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: uint32(ipv4.ICMPTypeTimeExceeded), SkipTrue: 6, SkipFalse: 0},
+
+		// BRANCH 2: Is this packet an ICMP Echo Reply?
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: uint32(ipv4.ICMPTypeEchoReply), SkipTrue: 1, SkipFalse: 0},
+		bpf.RetConstant{Val: 0}, // Reject if neither type
+
+		// ACTION: Match ID of the ICMP Echo Reply (Offset 4)
+		bpf.LoadIndirect{Off: 4, Size: 2},
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: uint32(id), SkipTrue: 0, SkipFalse: 1},
+
+		bpf.RetConstant{Val: ^uint32(0)}, // ACCEPT
+		bpf.RetConstant{Val: 0},          // REJECT
+		bpf.RetConstant{Val: ^uint32(0)}, // ACCEPT (Time Exceeded jump target)
 	})
 	if err != nil {
 		return err
@@ -159,15 +172,25 @@ func (c *icmpv4Conn) InstallICMPIDFilter(id int) error {
 }
 
 // InstallICMPIDFilter attaches a BPF program to the connection to filter ICMPv6 packets id.
+// Also accepts Time Exceeded messages.
 func (c *icmpV6Conn) InstallICMPIDFilter(id int) error {
 	filter, err := bpf.Assemble([]bpf.Instruction{
-		bpf.LoadAbsolute{Off: 0, Size: 1}, // Load ICMP type
-		bpf.JumpIf{Cond: bpf.JumpEqual, Val: uint32(ipv6.ICMPTypeEchoReply), SkipTrue: 1, SkipFalse: 0}, // Check if it is an ICMP6 echo reply
-		bpf.RetConstant{Val: 0},           // Reject if false
-		bpf.LoadAbsolute{Off: 4, Size: 2}, // Load ICMP echo identifier
-		bpf.JumpIf{Cond: bpf.JumpEqual, Val: uint32(id), SkipTrue: 0, SkipFalse: 1}, // Check if it matches our identifier
-		bpf.RetConstant{Val: ^uint32(0)},                                            // Accept if true
-		bpf.RetConstant{Val: 0},                                                     // Reject if false
+		// Load ICMPv6 type
+		bpf.LoadAbsolute{Off: 0, Size: 1},
+
+		// BRANCH 1: Is this packet type Time Exceeded?
+		// If yes, ACCEPT immediately. We will filter by ID in Go (User Space).
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: uint32(ipv6.ICMPTypeTimeExceeded), SkipTrue: 3, SkipFalse: 0},
+
+		// BRANCH 2: Is this packet an ICMP Echo Reply?
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: uint32(ipv6.ICMPTypeEchoReply), SkipTrue: 0, SkipFalse: 3},
+
+		// ACTION: Match ID of the ICMP Echo Reply (Offset 4)
+		bpf.LoadAbsolute{Off: 4, Size: 2},
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: uint32(id), SkipTrue: 0, SkipFalse: 1},
+
+		bpf.RetConstant{Val: ^uint32(0)}, // ACCEPT
+		bpf.RetConstant{Val: 0},          // REJECT
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Allow pro-bing library to receive and process ICMP time exceeded messages.

Add new callback OnTimeExceeded to handle ICMP Type 11 (Time Exceeded) events.

This is useful when you want to catch ICMP time exceeded messages, in order to implement traceroute-like tools.

Fixes #194