### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -16,51 +16,51 @@ package probing
 import "log"
 
 type Logger interface {
-	Fatalf(format string, v ...interface{})
-	Errorf(format string, v ...interface{})
-	Warnf(format string, v ...interface{})
-	Infof(format string, v ...interface{})
-	Debugf(format string, v ...interface{})
+	Fatalf(format string, v ...any)
+	Errorf(format string, v ...any)
+	Warnf(format string, v ...any)
+	Infof(format string, v ...any)
+	Debugf(format string, v ...any)
 }
 
 type StdLogger struct {
 	Logger *log.Logger
 }
 
-func (l StdLogger) Fatalf(format string, v ...interface{}) {
+func (l StdLogger) Fatalf(format string, v ...any) {
 	l.Logger.Printf("FATAL: "+format, v...)
 }
 
-func (l StdLogger) Errorf(format string, v ...interface{}) {
+func (l StdLogger) Errorf(format string, v ...any) {
 	l.Logger.Printf("ERROR: "+format, v...)
 }
 
-func (l StdLogger) Warnf(format string, v ...interface{}) {
+func (l StdLogger) Warnf(format string, v ...any) {
 	l.Logger.Printf("WARN: "+format, v...)
 }
 
-func (l StdLogger) Infof(format string, v ...interface{}) {
+func (l StdLogger) Infof(format string, v ...any) {
 	l.Logger.Printf("INFO: "+format, v...)
 }
 
-func (l StdLogger) Debugf(format string, v ...interface{}) {
+func (l StdLogger) Debugf(format string, v ...any) {
 	l.Logger.Printf("DEBUG: "+format, v...)
 }
 
 type NoopLogger struct {
 }
 
-func (l NoopLogger) Fatalf(format string, v ...interface{}) {
+func (l NoopLogger) Fatalf(format string, v ...any) {
 }
 
-func (l NoopLogger) Errorf(format string, v ...interface{}) {
+func (l NoopLogger) Errorf(format string, v ...any) {
 }
 
-func (l NoopLogger) Warnf(format string, v ...interface{}) {
+func (l NoopLogger) Warnf(format string, v ...any) {
 }
 
-func (l NoopLogger) Infof(format string, v ...interface{}) {
+func (l NoopLogger) Infof(format string, v ...any) {
 }
 
-func (l NoopLogger) Debugf(format string, v ...interface{}) {
+func (l NoopLogger) Debugf(format string, v ...any) {
 }

--- a/ping.go
+++ b/ping.go
@@ -120,7 +120,7 @@ func New(addr string) *Pinger {
 		Timeout:    time.Duration(math.MaxInt64),
 
 		addr:              addr,
-		done:              make(chan interface{}),
+		done:              make(chan any),
 		id:                r.Intn(math.MaxUint16),
 		trackerUUIDs:      []uuid.UUID{firstUUID},
 		ipaddr:            nil,
@@ -225,7 +225,7 @@ type Pinger struct {
 	InterfaceName string
 
 	// Channel and mutex used to communicate when the Pinger should stop between goroutines.
-	done chan interface{}
+	done chan any
 	lock sync.Mutex
 
 	ipaddr *net.IPAddr


### PR DESCRIPTION
Replace `interface{}` with `any` (Go 1.18+ type alias) in `ping.go` and `logger.go`.