### PR TITLE
Fix ping test

### DIFF
--- a/ping_test.go
+++ b/ping_test.go
@@ -889,9 +889,11 @@ func TestSetResolveTimeout(t *testing.T) {
 }
 
 func TestRunStatisticsConcurrent(t *testing.T) {
-	p := New("www.google.com")
+	p := New("localhost")
 	p.Count = 1
 	p.Interval = time.Millisecond
+	p.Timeout = time.Second
 	go p.Statistics()
-	p.Run()
+	err := p.Run()
+	AssertNoError(t, err)
 }


### PR DESCRIPTION
Use localhost to run the statistics test to avoid sending packets out over the internet for `make test`.

Also make sure the statistics test pinger has a timeout and checks for no error.