### PR TITLE
Update build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
     exclude-paths:
       - .github/workflows/container_description.yml
       - .github/workflows/golangci-lint.yml
+      - .github/workflows/scorecards.yml
+      - .github/workflows/stale.yml


### PR DESCRIPTION
* Update to Go 1.26.x.
* Update minimum Go version to 1.25.0.
* Bump Go modules.
* Enable dpendabot for GitHub Actions.
* Use latest semver for goreleaser.
* Bump GitHub Actions.
* Cleanup obsolete GO111MODULE use.