### PR TITLE
docs: correct the unprivileged ping description

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,11 @@ $GOPATH/bin/ping
 ## Supported Operating Systems
 
 ### Linux
-This library attempts to send an "unprivileged" ping via UDP. On Linux,
-this must be enabled with the following sysctl command:
+This library attempts to send an "unprivileged" ping. This still sends ICMP echo
+requests, not UDP packets: it opens a datagram socket (`SOCK_DGRAM` with
+`IPPROTO_ICMP`) instead of a raw socket, which is why the Go network name for it
+is `udp4`/`udp6`. On Linux, this must be enabled with the following sysctl
+command:
 
 ```
 sudo sysctl -w net.ipv4.ping_group_range="0 2147483647"

--- a/ping.go
+++ b/ping.go
@@ -468,7 +468,8 @@ func (p *Pinger) SetNetwork(n string) {
 }
 
 // SetPrivileged sets the type of ping pinger will send.
-// false means pinger will send an "unprivileged" UDP ping.
+// false means pinger will send an "unprivileged" ping over a datagram ICMP
+// socket. Both modes send ICMP echo requests; only the socket type differs.
 // true means pinger will send a "privileged" raw ICMP ping.
 // NOTE: setting to true requires that it be run with super-user privileges.
 func (p *Pinger) SetPrivileged(privileged bool) {


### PR DESCRIPTION
Closes #214.

## What is wrong

The README and the `SetPrivileged` doc comment both describe the unprivileged mode as a ping sent "via UDP":

> This library attempts to send an "unprivileged" ping via UDP.

> `false` means pinger will send an "unprivileged" UDP ping.

No UDP packet is ever sent. `pro-bing` passes the network name `udp4`/`udp6` to `icmp.ListenPacket` (ping.go:102-103, ping.go:1003-1007), and `x/net/icmp` maps those to a **datagram ICMP socket**, not a UDP one:

```go
// golang.org/x/net/icmp/listen_posix.go
case "udp4":
	family, proto = syscall.AF_INET, iana.ProtocolICMP
case "udp6":
	family, proto = syscall.AF_INET6, iana.ProtocolIPv6ICMP
...
s, err := syscall.Socket(family, syscall.SOCK_DGRAM, proto)
```

So `udp` here names the *socket type* (`SOCK_DGRAM` rather than `SOCK_RAW`), not the transport protocol. Both modes put ICMP echo requests on the wire.

## Verified on the wire

Tracing the syscall a `SetPrivileged(false)` pinger actually makes on Linux 6.17:

```
$ strace -f -e trace=socket ./probecheck
socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP) = -1 EACCES (Permission denied)
```

Protocol `IPPROTO_ICMP` (1), not `IPPROTO_UDP` (17). The `EACCES` is the same machine's `net.ipv4.ping_group_range = 1 0`, i.e. exactly the sysctl the README goes on to document.

## Change

Docs only, no behaviour change. Corrects both places that state it, and keeps the explanation of *why* the Go network name says `udp` so the next reader does not re-derive this. `gofmt`, `go vet ./...` and `go build ./...` are clean.

Thanks @SuperQ for confirming the report on the issue.